### PR TITLE
Add user profile endpoints

### DIFF
--- a/nutriflow/db/supabase.py
+++ b/nutriflow/db/supabase.py
@@ -178,3 +178,27 @@ def update_daily_summary(
     if not response.data:
         raise Exception("Erreur update daily_summary")
     return response.data[0]
+
+
+def get_user(user_id):
+    supabase = get_supabase_client()
+    response = (
+        supabase.table("users")
+        .select("*")
+        .eq("id", user_id)
+        .execute()
+    )
+    return response.data[0] if response.data else None
+
+
+def update_user(user_id, data):
+    supabase = get_supabase_client()
+    response = (
+        supabase.table("users")
+        .update(data)
+        .eq("id", user_id)
+        .execute()
+    )
+    if not response.data:
+        raise Exception("Erreur update user")
+    return response.data[0]


### PR DESCRIPTION
## Summary
- support user profile CRUD in router
- update Supabase helper with get/update user methods
- extend API tests for new profile endpoints

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e48bac0808325b5bedd0f3c97b787