### PR TITLE
Add manual sport mapping and /sports endpoint

### DIFF
--- a/nutriflow/api/router.py
+++ b/nutriflow/api/router.py
@@ -21,7 +21,8 @@ from nutriflow.services import (
     convert_nutritionix_to_df,
     calculate_totals,
     calculer_bmr,
-    calculer_tdee
+    calculer_tdee,
+    SPORTS_MAPPING
 )
 
 router = APIRouter()
@@ -175,6 +176,12 @@ def search(query: str = Query(..., min_length=1, description="Terme de recherche
     if not prod:
         raise HTTPException(status_code=404, detail="Produit non trouvé")
     return OFFProduct(**prod)
+
+
+@router.get("/sports", response_model=List[str])
+def get_supported_sports() -> List[str]:
+    """Retourne la liste des activités sportives reconnues."""
+    return list(SPORTS_MAPPING.keys())
 
 @router.post("/exercise", response_model=List[ExerciseResult])
 def exercise(data: ExerciseQuery):


### PR DESCRIPTION
## Summary
- translate activity text with manual sport mapping and fallback to Google Translate
- log final query sent to Nutritionix
- expose sports list via `/api/sports`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8046bd248325bf8aa51104e3b17f