### PR TITLE
Adjust daily summary column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,17 +172,17 @@ Elle permet d’analyser, enregistrer et restituer :
 ```
 - Réponse : liste d’exercices analysés
 
-### `/api/daily-summary`
+-### `/api/daily-summary`
 - Calcule ou lit le bilan nutritionnel du jour (apports, dépenses, TDEE, balance, conseil).
 - Paramètre : `date_str` (optionnel)
 - Exemple de réponse :
 ```json
 {
   "date": "2025-07-21",
-  "total_calories": 1700,
-  "total_sport": 300,
+  "calories_apportees": 1700,
+  "calories_brulees": 300,
   "tdee": 2100,
-  "balance": -400,
+  "balance_calorique": -400,
   "conseil": "Déficit modéré, bonne trajectoire pour perdre du poids."
 }
 ```

--- a/nutriflow/db/supabase.py
+++ b/nutriflow/db/supabase.py
@@ -123,10 +123,10 @@ def get_daily_summaries(user_id, limit=30):
 def insert_daily_summary(
     user_id,
     date,
-    total_calories,
-    total_sport,
     tdee,
-    balance,
+    calories_apportees,
+    calories_brulees,
+    balance_calorique,
     conseil,
 ):
     supabase = get_supabase_client()
@@ -136,10 +136,10 @@ def insert_daily_summary(
             {
                 "user_id": user_id,
                 "date": date,
-                "total_calories": total_calories,
-                "total_sport": total_sport,
                 "tdee": tdee,
-                "balance": balance,
+                "calories_apportees": calories_apportees,
+                "calories_brulees": calories_brulees,
+                "balance_calorique": balance_calorique,
                 "conseil": conseil,
             }
         )
@@ -153,10 +153,10 @@ def insert_daily_summary(
 def update_daily_summary(
     user_id,
     date,
-    total_calories,
-    total_sport,
     tdee,
-    balance,
+    calories_apportees,
+    calories_brulees,
+    balance_calorique,
     conseil,
 ):
     supabase = get_supabase_client()
@@ -164,10 +164,10 @@ def update_daily_summary(
         supabase.table("daily_summary")
         .update(
             {
-                "total_calories": total_calories,
-                "total_sport": total_sport,
                 "tdee": tdee,
-                "balance": balance,
+                "calories_apportees": calories_apportees,
+                "calories_brulees": calories_brulees,
+                "balance_calorique": balance_calorique,
                 "conseil": conseil,
             }
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -90,19 +90,19 @@ def mock_router(monkeypatch):
     monkeypatch.setattr(db, 'insert_activity', lambda *args, **kwargs: 'fake-activity-id')
     monkeypatch.setattr(db, 'get_daily_summary', lambda *args, **kwargs: {
         "date": args[1] if len(args) > 1 else kwargs.get('date'),
-        "total_calories": 2000.0,
-        "total_sport": 300.0,
+        "calories_apportees": 2000.0,
+        "calories_brulees": 300.0,
         "tdee": 1800.0,
-        "balance": 200.0,
+        "balance_calorique": 200.0,
         "conseil": "test"
     })
     monkeypatch.setattr(db, 'get_daily_summaries', lambda *args, **kwargs: [
         {
             "date": "2023-01-01",
-            "total_calories": 2000.0,
-            "total_sport": 300.0,
+            "calories_apportees": 2000.0,
+            "calories_brulees": 300.0,
             "tdee": 1800.0,
-            "balance": 200.0,
+            "balance_calorique": 200.0,
             "conseil": "test"
         }
     ])
@@ -262,7 +262,7 @@ def test_daily_summary_integration_structure():
             res = await ac.get("/api/daily-summary", params={"date_str": "2023-01-02"})
             assert res.status_code == 200
             data = res.json()
-            assert all(k in data for k in ("date", "total_calories", "total_sport", "tdee", "balance", "conseil"))
+            assert all(k in data for k in ("date", "calories_apportees", "calories_brulees", "tdee", "balance_calorique", "conseil"))
     run_async(inner())
 
 
@@ -275,7 +275,7 @@ def test_history_integration_structure():
             data = res.json()
             assert isinstance(data, list) and data
             first = data[0]
-            assert all(k in first for k in ("date", "total_calories", "total_sport", "tdee", "balance", "conseil"))
+            assert all(k in first for k in ("date", "calories_apportees", "calories_brulees", "tdee", "balance_calorique", "conseil"))
     run_async(inner())
 
 


### PR DESCRIPTION
## Summary
- map /api/daily-summary to new Supabase column names
- update Supabase insert/update helpers
- tweak history endpoint and tests
- reflect API change in docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e85ccf0508325b9dfb9fbc0418459