### PR TITLE
Fix translation using LibreTranslate

### DIFF
--- a/nutriflow/services.py
+++ b/nutriflow/services.py
@@ -2,7 +2,6 @@ import os
 import requests
 import pandas as pd
 import unicodedata
-import os
 from typing import List, Dict, Optional
 from fastapi import HTTPException
 from libretranslatepy import LibreTranslateAPI
@@ -88,13 +87,12 @@ def translate_fr_en(text_fr: str) -> str:
     url = os.getenv("NUTRIFLOW_LIBRETRANSLATE_URL", "https://libretranslate.de")
     translator = LibreTranslateAPI(url)
     try:
-        result = translator.translate(cleaned, source="fr", target="en")
-        print(
-            f"\N{CLOCKWISE OPEN CIRCLE ARROW} Traduction automatique : {cleaned} → {result}"
-        )
+        print(f"[TRAD] Texte avant : {cleaned}")
+        result = translator.translate(cleaned, "fr", "en")
+        print(f"[TRAD] Texte après : {result}")
         return result
     except Exception as e:
-        print(f"\N{CROSS MARK} Erreur traduction : {e}")
+        print(f"[TRAD][ERREUR] {e}")
         return text_fr
 
 


### PR DESCRIPTION
## Summary
- clean up imports in `services.py`
- log text before/after translation and handle errors properly
- use `LibreTranslateAPI.translate(text, "fr", "en")`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `python - <<'EOF'
from nutriflow.services import translate_fr_en
print(translate_fr_en('pomme'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687f4370290483258e4b8061ec429e5a