### PR TITLE
Restore googletrans for translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ NutriFlow est une API en **FastAPI** qui t'aide à suivre ta nutrition et tes ac
    # Supabase
    SUPABASE_URL=https://xxxx.supabase.co
    SUPABASE_KEY=ta_cle_supabase
-
-   # LibreTranslate (optionnel)
-   NUTRIFLOW_LIBRETRANSLATE_URL=http://localhost:5000
    ```
 4. **Démarrage de l'API**
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ uvicorn[standard]
 python-dotenv
 requests
 pandas
-libretranslatepy
+googletrans
 httpx
 supabase


### PR DESCRIPTION
## Summary
- revert translation code back to `googletrans`
- update environment variable section in README
- switch requirements back to `googletrans`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f48a98f4083259df15a5fc58fe167