### PR TITLE
Ajout repas par code-barres

### DIFF
--- a/nutriflow/db/supabase.py
+++ b/nutriflow/db/supabase.py
@@ -34,6 +34,7 @@ def insert_meal_item(
     glucides_g,
     lipides_g,
     barcode=None,
+    source=None,
 ):
     supabase = get_supabase_client()
     response = (
@@ -50,6 +51,7 @@ def insert_meal_item(
                 "glucides_g": glucides_g,
                 "lipides_g": lipides_g,
                 "barcode": barcode,
+                "source": source,
             }
         )
         .execute()


### PR DESCRIPTION
## Résumé
- possibilité de spécifier le type de repas lors de l'ajout d'ingrédients
- sauvegarde d'un produit scanné dans un repas du jour (créé au besoin)
- traçage de la source des aliments dans `meal_items`

## Test
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f85c8f2f88325871f3dd06b31124b