### PR TITLE
Handle missing column when inserting meal item

### DIFF
--- a/nutriflow/db/supabase.py
+++ b/nutriflow/db/supabase.py
@@ -37,25 +37,27 @@ def insert_meal_item(
     source=None,
 ):
     supabase = get_supabase_client()
-    response = (
-        supabase.table("meal_items")
-        .insert(
-            {
-                "meal_id": meal_id,
-                "nom_aliment": nom_aliment,
-                "marque": marque,
-                "quantite": quantite,
-                "unite": unite,
-                "calories": calories,
-                "proteines_g": proteines_g,
-                "glucides_g": glucides_g,
-                "lipides_g": lipides_g,
-                "barcode": barcode,
-                "source": source,
-            }
-        )
-        .execute()
-    )
+    payload = {
+        "meal_id": meal_id,
+        "nom_aliment": nom_aliment,
+        "marque": marque,
+        "quantite": quantite,
+        "unite": unite,
+        "calories": calories,
+        "proteines_g": proteines_g,
+        "glucides_g": glucides_g,
+        "lipides_g": lipides_g,
+        "barcode": barcode,
+        "source": source,
+    }
+    try:
+        response = supabase.table("meal_items").insert(payload).execute()
+    except APIError as e:
+        if getattr(e, "code", "") == "PGRST204" and "source" in str(e):
+            payload.pop("source", None)
+            response = supabase.table("meal_items").insert(payload).execute()
+        else:
+            raise
     if not response.data:
         raise Exception("Erreur insertion meal_item")
     return response.data[0]["id"]


### PR DESCRIPTION
## Summary
- handle missing `source` column in `insert_meal_item`
- add fallback insert when Supabase table does not contain `source`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f883101c8832593eae47e398839d5