### PR TITLE
Fix CSV mapping loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,10 @@ resultat = translate_fr_en(phrase)
 print(resultat)
 ```
 
+Format attendu du CSV :
+- deux colonnes nommées `fr` et `en`
+- séparateur `;` ou `,` accepté
+
 L'appel à Google Translate reçoit déjà :
 `2 tablespoons of blueberry jam`.
 

--- a/nutriflow/services.py
+++ b/nutriflow/services.py
@@ -78,8 +78,13 @@ DEFAULT_MAPPING_PATH = os.path.join(
 _CSV_MAPPING: Optional[Dict[str, str]] = None
 
 def load_mapping_csv(filepath: str) -> Dict[str, str]:
-    """Charge un CSV `fr,en` et retourne un dictionnaire {fr: en}."""
-    df = pd.read_csv(filepath)
+    """Charge un CSV "fr,en" ou "fr;en" et retourne un dictionnaire."""
+    # On détecte automatiquement le séparateur utilisé
+    with open(filepath, "r", encoding="utf-8-sig") as f:
+        first_line = f.readline()
+    delimiter = ";" if first_line.count(";") >= first_line.count(",") else ","
+
+    df = pd.read_csv(filepath, sep=delimiter)
     mapping = {}
     for _, row in df.iterrows():
         fr = clean_text(str(row["fr"]))


### PR DESCRIPTION
## Summary
- make `load_mapping_csv` detect `;` or `,` separator
- document expected CSV format in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fbf11ec60832590b1de32dbf4ec5d