### PR TITLE
Ajout modèle BarcodeQueryUserInput

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,7 +15,7 @@ from main import app
 from nutriflow.api import router
 from nutriflow.api.router import (
     IngredientQuery,
-    BarcodeQuery,
+    BarcodeQueryUserInput,
     ExerciseQuery,
     BMRQuery,
     TDEEQuery,
@@ -192,10 +192,11 @@ def test_ingredients_unit():
 
 
 def test_barcode_unit():
-    q = BarcodeQuery(barcode="12345678")
+    q = BarcodeQueryUserInput(barcode="12345678", quantity=50)
     resp = router.barcode(q)
     assert isinstance(resp, OFFProduct)
     assert resp.name == "TestProduct"
+    assert resp.energy_kcal_per_100g == 50
 
 
 def test_search_unit():
@@ -309,7 +310,10 @@ def test_barcode_integration_structure():
     async def inner():
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
-            res = await ac.post("/api/barcode", json={"barcode": "3274080005003"})
+            res = await ac.post(
+                "/api/barcode",
+                json={"barcode": "3274080005003", "quantity": 100},
+            )
             assert res.status_code in (200, 404)
             if res.status_code == 200:
                 data = res.json()


### PR DESCRIPTION
## Résumé
- ajoute le modèle `BarcodeQueryUserInput`
- la route `/api/barcode` gère automatiquement le repas du jour et insère l'aliment depuis OpenFoodFacts
- renvoie les valeurs nutritionnelles recalculées selon la quantité
- met à jour les tests unitaires et d'intégration

## Tests
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fd230dbc083258e62e3c47b212f72