### PR TITLE
Connect frontend meal modal to FastAPI

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,37 @@
+export interface Totals {
+  total_calories: number;
+  total_proteins_g: number;
+  total_carbs_g: number;
+  total_fats_g: number;
+}
+
+export interface NutritionixFood {
+  aliment: string;
+  quantite: string;
+  poids_g: number;
+  calories: number;
+  proteines_g: number;
+  glucides_g: number;
+  lipides_g: number;
+}
+
+export interface NutritionixResponse {
+  foods: NutritionixFood[];
+  totals: Totals;
+}
+
+export async function analyzeIngredients(input: string, mealType: string): Promise<NutritionixResponse> {
+  console.log('Données envoyées :', { query: input, type: mealType });
+  const res = await fetch('http://localhost:8000/api/ingredients', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: input, type: mealType })
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Erreur API ${res.status}: ${text}`);
+  }
+  const data = (await res.json()) as NutritionixResponse;
+  console.log('Réponse reçue :', data);
+  return data;
+}


### PR DESCRIPTION
## Summary
- add API helper to call `POST /api/ingredients`
- connect `AddMealModal` with backend and display nutrition summary

## Testing
- `npm run lint` *(fails: no-empty-object-type & no-require-imports errors)*
- `npm run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688113f6ad08832588689e974a3fc769