### PR TITLE
Fix ingredient insertion using existing meal

### DIFF
--- a/nutriflow/api/router.py
+++ b/nutriflow/api/router.py
@@ -190,7 +190,15 @@ def ingredients(data: IngredientQuery):
 
         # === AJOUT SAUVEGARDE DANS SUPABASE ===
         user_id = TEST_USER_ID  # ID générique en l'absence d'utilisateur connecté
-        meal_id = insert_meal(user_id, str(date.today()), data.type, note="")
+        today = str(date.today())
+        meal_id = None
+        meals = db.get_meals(user_id, today)
+        for m in meals:
+            if m.get("type") == data.type:
+                meal_id = m.get("id")
+                break
+        if not meal_id:
+            meal_id = insert_meal(user_id, today, data.type, note="")
         for food in foods:
             insert_meal_item(
                 meal_id=meal_id,


### PR DESCRIPTION
## Summary
- allow `/api/ingredients` to reuse an existing meal for the same date and type
- test that ingredients are linked to the existing meal instead of creating a new one

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881e05c83dc8325b5d8689e49283efe