### PR TITLE
Ajout édition du type de repas

### DIFF
--- a/nutriflow/api/router.py
+++ b/nutriflow/api/router.py
@@ -131,6 +131,8 @@ class MealPatchPayload(BaseModel):
     add: Optional[List[MealItemCreate]] = None
     update: Optional[List[MealItemUpdate]] = None
     delete: Optional[List[str]] = None
+    type: Optional[str] = None
+    date: Optional[str] = None
 
 
 # ----- Response Models -----
@@ -493,6 +495,13 @@ def list_meals(
 @router.patch("/meals/{meal_id}")
 def edit_meal(meal_id: str, payload: MealPatchPayload):
     """Ajoute, met à jour ou supprime des ingrédients d'un repas."""
+    meal_data = {}
+    if payload.type is not None:
+        meal_data["type"] = payload.type
+    if payload.date is not None:
+        meal_data["date"] = payload.date
+    if meal_data:
+        db.update_meal(meal_id, meal_data)
     if payload.add:
         for item in payload.add:
             db.insert_meal_item(meal_id=meal_id, **item.dict())

--- a/nutriflow/db/supabase.py
+++ b/nutriflow/db/supabase.py
@@ -106,6 +106,13 @@ def get_meal_items(meal_id):
     return response.data or []
 
 
+def update_meal(meal_id, data):
+    """Met à jour un repas."""
+    supabase = get_supabase_client()
+    response = supabase.table("meals").update(data).eq("id", meal_id).execute()
+    return response.data[0] if response.data else None
+
+
 def update_meal_item(item_id, data):
     """Met à jour un aliment d'un repas."""
     supabase = get_supabase_client()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -178,6 +178,7 @@ def mock_router(monkeypatch):
         return SAMPLE_USER
 
     monkeypatch.setattr(db, "update_user", _update_user)
+    monkeypatch.setattr(db, "update_meal", lambda *args, **kwargs: None)
 
 
 # ----- Unit Tests -----
@@ -632,3 +633,18 @@ def test_units_endpoint_integration():
             assert "cuil. a soupe" in data
 
     run_async(inner())
+
+
+def test_edit_meal_update_type(monkeypatch):
+    record = {}
+
+    def fake_update(meal_id, data):
+        record["meal_id"] = meal_id
+        record.update(data)
+
+    monkeypatch.setattr(db, "update_meal", fake_update)
+    payload = router.MealPatchPayload(type="diner")
+    resp = router.edit_meal("meal123", payload)
+    assert record["meal_id"] == "meal123"
+    assert record["type"] == "diner"
+    assert resp["id"] == "meal123"


### PR DESCRIPTION
## Résumé
- étend `MealPatchPayload` avec les champs optionnels `type` et `date`
- ajoute la fonction `update_meal` pour mettre à jour la table `meals`
- met à jour l'endpoint `edit_meal` pour appliquer ces changements
- couvre la mise à jour du type de repas dans les tests

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f453479c83258cc1bae5bc186ec7