### PR TITLE
Add meals page with navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Meals from "./pages/Meals";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/meals" element={<Meals />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/frontend/src/components/QuickActions.tsx
+++ b/frontend/src/components/QuickActions.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Plus, UtensilsCrossed, Dumbbell, Scan } from "lucide-react";
+import { Plus, UtensilsCrossed, Dumbbell, Scan, List } from "lucide-react";
+import { Link } from "react-router-dom";
 import { AddMealModal } from "./AddMealModal";
 import { AddActivityModal } from "./AddActivityModal";
 import { ScanProductModal } from "./ScanProductModal";
@@ -22,7 +23,7 @@ export const QuickActions = ({}: QuickActionsProps) => {
       <CardHeader>
         <CardTitle className="text-lg font-semibold text-foreground">Actions rapides</CardTitle>
       </CardHeader>
-      <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-3">
+      <CardContent className="grid grid-cols-1 md:grid-cols-4 gap-3">
         <Button 
           onClick={() => setAddMealOpen(true)}
           variant="default"
@@ -41,13 +42,20 @@ export const QuickActions = ({}: QuickActionsProps) => {
           Activité sportive
         </Button>
         
-        <Button 
+        <Button
           onClick={() => setScanProductOpen(true)}
           variant="outline"
           className="flex items-center gap-2 h-12 hover:shadow-medium transition-all duration-300 border-accent text-accent hover:bg-accent hover:text-accent-foreground"
         >
           <Scan className="h-4 w-4" />
           Scanner produit
+        </Button>
+
+        <Button asChild variant="outline" className="flex items-center gap-2 h-12 hover:shadow-medium transition-all duration-300">
+          <Link to="/meals">
+            <List className="h-4 w-4" />
+            Mes repas
+          </Link>
         </Button>
       </CardContent>
     </Card>

--- a/frontend/src/pages/Meals.tsx
+++ b/frontend/src/pages/Meals.tsx
@@ -1,0 +1,26 @@
+import { SidebarProvider, SidebarTrigger, SidebarInset } from "@/components/ui/sidebar";
+import { AppSidebar } from "@/components/AppSidebar";
+import { MealList } from "@/components/MealList";
+
+const Meals = () => (
+  <SidebarProvider>
+    <div className="min-h-screen flex w-full bg-background">
+      <AppSidebar />
+      <SidebarInset className="flex-1">
+        <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+          <div className="flex h-16 items-center gap-4 px-6">
+            <SidebarTrigger />
+            <div className="flex-1">
+              <h1 className="text-2xl font-bold bg-gradient-primary bg-clip-text text-transparent">Mes repas</h1>
+            </div>
+          </div>
+        </header>
+        <main className="flex-1 space-y-6 p-6">
+          <MealList />
+        </main>
+      </SidebarInset>
+    </div>
+  </SidebarProvider>
+);
+
+export default Meals;


### PR DESCRIPTION
## Summary
- create Meals page with MealList component
- add route to `/meals`
- link to meals from QuickActions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f45b26dc832591ec5835b729aa78