### PR TITLE
Fix ingredient query spacing

### DIFF
--- a/frontend/src/components/AddMealModal.tsx
+++ b/frontend/src/components/AddMealModal.tsx
@@ -95,7 +95,7 @@ export const AddMealModal = ({
       return;
     }
     const query = ingredients
-      .map((ing) => `${ing.quantity}${ing.unit} ${ing.name}`)
+      .map((ing) => `${ing.quantity} ${ing.unit} ${ing.name}`)
       .join(", ");
 
     try {


### PR DESCRIPTION
## Summary
- fix AddMealModal query generation to include spaces between quantity, unit and name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f6dd32cc83259cc9b4c41c95ccf2