### PR TITLE
Ajout de l'analyse Nutritionix à l'édition de repas

### DIFF
--- a/frontend/src/components/EditMealModal.tsx
+++ b/frontend/src/components/EditMealModal.tsx
@@ -60,9 +60,11 @@ export const EditMealModal = ({ meal, open, onOpenChange, onUpdated }: EditMealM
       delete: deletedIds.length ? deletedIds : undefined,
     };
     try {
-      await updateMeal(meal.id, payload);
+      const updated = await updateMeal(meal.id, payload);
+      setMealType(updated.type);
+      setItems(updated.ingredients.map((it) => ({ ...it })));
+      setDeletedIds([]);
       toast({ title: "Repas mis à jour" });
-      onOpenChange(false);
       onUpdated();
     } catch (err) {
       console.error(err);

--- a/nutriflow/db/supabase.py
+++ b/nutriflow/db/supabase.py
@@ -106,6 +106,13 @@ def get_meal_items(meal_id):
     return response.data or []
 
 
+def get_meal(meal_id):
+    """Récupère un repas par son identifiant."""
+    supabase = get_supabase_client()
+    response = supabase.table("meals").select("*").eq("id", meal_id).execute()
+    return response.data[0] if response.data else None
+
+
 def update_meal(meal_id, data):
     """Met à jour un repas."""
     supabase = get_supabase_client()


### PR DESCRIPTION
## Résumé
- ajout d'une fonction `_analyze_item` côté API
- appel systématique à Nutritionix lors de l'ajout ou la modification d'ingrédients
- enregistrement complet des nutriments dans `meal_items`
- retour du repas actualisé et mise à jour de la modale côté front
- tests unitaires couvrant ces nouvelles fonctionnalités

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f94aeb40832593286be4679146eb