### PR TITLE
Fix meal item insertion without brand

### DIFF
--- a/nutriflow/db/supabase.py
+++ b/nutriflow/db/supabase.py
@@ -26,13 +26,13 @@ def insert_meal(user_id, date, type_repas, note=""):
 def insert_meal_item(
     meal_id,
     nom_aliment,
-    marque,
     quantite,
     unite,
     calories,
     proteines_g,
     glucides_g,
     lipides_g,
+    marque=None,
     barcode=None,
     source=None,
 ):


### PR DESCRIPTION
## Summary
- allow `insert_meal_item` to skip `marque`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881fbd69ccc8325b7efa5c6f45f81ee