### PR TITLE
Improve activity UX with loading states and summary

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -184,3 +184,30 @@ export async function deleteActivity(activityId: string): Promise<void> {
     throw new Error(`Erreur API ${res.status}: ${text}`);
   }
 }
+
+export interface DailySummary {
+  date: string;
+  calories_apportees: number;
+  calories_brulees: number;
+  tdee: number;
+  balance_calorique: number;
+  conseil: string;
+}
+
+export async function fetchDailySummary(date: string): Promise<DailySummary> {
+  const res = await fetch(`http://localhost:8000/api/daily-summary?date=${date}`);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Erreur API ${res.status}: ${text}`);
+  }
+  return (await res.json()) as DailySummary;
+}
+
+export async function fetchSports(): Promise<string[]> {
+  const res = await fetch('http://localhost:8000/api/sports');
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Erreur API ${res.status}: ${text}`);
+  }
+  return (await res.json()) as string[];
+}


### PR DESCRIPTION
## Summary
- add daily summary and sports fetching to API client
- enhance AddActivityModal with auto-fill, saving state and suggestions
- show loading indicator and daily calories burned in ActivityList

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68821bf1e55083258d8c46ea7bb293db