### PR TITLE
Add activities endpoint

### DIFF
--- a/nutriflow/api/router.py
+++ b/nutriflow/api/router.py
@@ -560,3 +560,14 @@ def remove_meal_item(item_id: str):
     """Supprime un ingrédient d'un repas."""
     db.delete_meal_item(item_id)
     return {"status": "deleted"}
+
+
+# ----- Activities Management -----
+
+@router.get("/activities")
+def list_activities(
+    date: str = Query(default=str(date.today()), description="Date YYYY-MM-DD"),
+    user_id: str = TEST_USER_ID,
+):
+    """Retourne les activités sportives de l'utilisateur pour la date donnée."""
+    return db.get_activities(user_id, date)


### PR DESCRIPTION
## Summary
- expose new `/api/activities` endpoint in router

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882341b06c88325af32c2c0fbcf4163