### PR TITLE
Ajout vue produit détaillé

### DIFF
--- a/frontend/src/components/ProductDetailsModal.tsx
+++ b/frontend/src/components/ProductDetailsModal.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { fetchProductDetails, type ProductDetails } from "@/services/api";
+
+interface ProductDetailsModalProps {
+  barcode: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const ProductDetailsModal = ({ barcode, open, onOpenChange }: ProductDetailsModalProps) => {
+  const [details, setDetails] = useState<ProductDetails | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      fetchProductDetails(barcode)
+        .then(setDetails)
+        .catch(() => setDetails(null));
+    }
+  }, [barcode, open]);
+
+  if (!open) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Détails produit</DialogTitle>
+        </DialogHeader>
+        {details && (
+          <div className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>{details.name}</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {details.image_url && (
+                  <img src={details.image_url} alt={details.name} className="w-32 h-32 object-contain mx-auto" />
+                )}
+                <p className="text-sm text-muted-foreground">{details.brand}</p>
+                <div className="grid grid-cols-2 gap-2">
+                  <div>Calories: {details.energy_kcal_per_100g} kcal/100g</div>
+                  <div>Protéines: {details.proteins_per_100g} g</div>
+                  <div>Glucides: {details.carbs_per_100g} g</div>
+                  <div>Lipides: {details.fat_per_100g} g</div>
+                </div>
+                <p>Nutriscore: {details.nutriscore?.toUpperCase()}</p>
+                {details.ingredients && <p>Ingrédients: {details.ingredients}</p>}
+                {details.labels && <p>Labels: {details.labels}</p>}
+                {details.additives && <p>Additifs: {details.additives}</p>}
+                {details.traces && <p>Traces: {details.traces}</p>}
+                {details.countries && <p>Pays: {details.countries}</p>}
+              </CardContent>
+            </Card>
+            <Separator />
+            <Button asChild variant="outline" className="w-full">
+              <a href={`https://world.openfoodfacts.org/product/${barcode}`} target="_blank" rel="noreferrer">
+                Voir sur OpenFoodFacts
+              </a>
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -236,3 +236,46 @@ export async function fetchSports(): Promise<string[]> {
   }
   return (await res.json()) as string[];
 }
+
+export interface ProductSummary {
+  barcode: string;
+  name: string;
+  image_url?: string;
+  brand?: string;
+  energy_kcal_per_100g?: number;
+  proteins_per_100g?: number;
+  carbs_per_100g?: number;
+  fat_per_100g?: number;
+  nutriscore?: string;
+}
+
+export interface ProductDetails extends ProductSummary {
+  labels?: string;
+  ingredients?: string;
+  additives?: string;
+  traces?: string;
+  countries?: string;
+  nova_score?: number;
+}
+
+export async function fetchProductSummary(barcode: string): Promise<ProductSummary> {
+  const res = await fetch('http://localhost:8000/api/barcode', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ barcode, quantity: 100 })
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Erreur API ${res.status}: ${text}`);
+  }
+  return (await res.json()) as ProductSummary;
+}
+
+export async function fetchProductDetails(barcode: string): Promise<ProductDetails> {
+  const res = await fetch(`http://localhost:8000/api/products/${barcode}/details`);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Erreur API ${res.status}: ${text}`);
+  }
+  return (await res.json()) as ProductDetails;
+}

--- a/nutriflow/db/supabase.py
+++ b/nutriflow/db/supabase.py
@@ -315,6 +315,15 @@ def get_user(user_id):
     return response.data[0] if response.data else None
 
 
+def get_product(barcode: str):
+    """Récupère un produit depuis la table `products` via son code-barres."""
+    supabase = get_supabase_client()
+    response = (
+        supabase.table("products").select("*").eq("barcode", barcode).execute()
+    )
+    return response.data[0] if response.data else None
+
+
 def update_user(user_id, data):
     supabase = get_supabase_client()
     response = supabase.table("users").update(data).eq("id", user_id).execute()

--- a/nutriflow/services.py
+++ b/nutriflow/services.py
@@ -355,13 +355,15 @@ def get_off_nutrition_by_barcode(barcode: str) -> Optional[Dict]:
         p = data["product"]
         n = p.get("nutriments", {})
         return {
+            "barcode": barcode,
             "name": p.get("product_name", "Inconnu"),
+            "image_url": p.get("image_front_url"),
             "brand": p.get("brands", "Inconnue"),
             "energy_kcal_per_100g": n.get("energy-kcal_100g"),
             "fat_per_100g": n.get("fat_100g"),
-            "sugars_per_100g": n.get("sugars_100g"),
+            "carbs_per_100g": n.get("carbohydrates_100g"),
             "proteins_per_100g": n.get("proteins_100g"),
-            "salt_per_100g": n.get("salt_100g"),
+            "nutriscore": p.get("nutriscore_grade"),
         }
     return None
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,6 +20,7 @@ from nutriflow.api.router import (
     BMRQuery,
     TDEEQuery,
     NutritionixResponse,
+    ProductSummary,
     OFFProduct,
     ExerciseResult,
     BMRResponse,
@@ -50,13 +51,22 @@ SAMPLE_EXERCISES = [
 ]
 
 SAMPLE_PRODUCT = {
+    "barcode": "12345678",
     "name": "TestProduct",
+    "image_url": "http://example.com/img.jpg",
     "brand": "BrandX",
     "energy_kcal_per_100g": 100,
     "fat_per_100g": 1.0,
-    "sugars_per_100g": 2.0,
+    "carbs_per_100g": 12.0,
     "proteins_per_100g": 3.0,
+    "sugars_per_100g": 2.0,
     "salt_per_100g": 0.5,
+    "nutriscore": "b",
+    "labels": "Vegan",
+    "ingredients": "water, sugar",
+    "additives": "E330",
+    "traces": "milk",
+    "countries": "France",
 }
 
 SAMPLE_USER = {
@@ -179,6 +189,7 @@ def mock_router(monkeypatch):
 
     monkeypatch.setattr(db, "update_user", _update_user)
     monkeypatch.setattr(db, "update_meal", lambda *args, **kwargs: None)
+    monkeypatch.setattr(db, "get_product", lambda *a, **k: SAMPLE_PRODUCT)
 
 
 # ----- Unit Tests -----
@@ -224,15 +235,20 @@ def test_ingredients_reuses_existing_meal(monkeypatch):
 def test_barcode_unit():
     q = BarcodeQueryUserInput(barcode="12345678", quantity=50)
     resp = router.barcode(q)
-    assert isinstance(resp, OFFProduct)
+    assert isinstance(resp, ProductSummary)
     assert resp.name == "TestProduct"
-    assert resp.energy_kcal_per_100g == 50
+    assert resp.energy_kcal_per_100g == 100
 
 
 def test_search_unit():
     resp = router.search(query="yogurt")
     assert isinstance(resp, OFFProduct)
     assert resp.energy_kcal_per_100g == 100
+
+
+def test_product_details_unit():
+    resp = router.product_details("12345678")
+    assert resp["name"] == "TestProduct"
 
 
 def test_exercise_unit():


### PR DESCRIPTION
## Résumé
- renvoie maintenant un résumé simple pour `/api/barcode`
- expose la route `/api/products/{barcode}/details`
- ajout de la fonction `get_product` côté Supabase
- ajout des appels API et de la modale `ProductDetailsModal` en React
- mise à jour des tests

## Tests
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68827bc0ab788325a38e3059ec6e7658