### PR TITLE
Fix barcode state for product details

### DIFF
--- a/frontend/src/components/ProductDetailsModal.tsx
+++ b/frontend/src/components/ProductDetailsModal.tsx
@@ -6,30 +6,36 @@ import { Separator } from "@/components/ui/separator";
 import { fetchProductDetails, type ProductDetails } from "@/services/api";
 
 interface ProductDetailsModalProps {
-  barcode: string;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+  barcode: string | null;
+  onClose: () => void;
 }
-
-export const ProductDetailsModal = ({ barcode, open, onOpenChange }: ProductDetailsModalProps) => {
+export const ProductDetailsModal = ({ barcode, onClose }: ProductDetailsModalProps) => {
   const [details, setDetails] = useState<ProductDetails | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (open) {
-      fetchProductDetails(barcode)
-        .then(setDetails)
-        .catch(() => setDetails(null));
-    }
-  }, [barcode, open]);
+    if (!barcode) return;
+    setLoading(true);
+    fetchProductDetails(barcode)
+      .then((data) => {
+        setDetails(data);
+        setError(null);
+      })
+      .catch(() => setError("Erreur lors du chargement."))
+      .finally(() => setLoading(false));
+  }, [barcode]);
 
-  if (!open) return null;
+  if (!barcode) return null;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={!!barcode} onOpenChange={(o) => { if (!o) onClose(); }}>
       <DialogContent className="max-w-xl">
         <DialogHeader>
           <DialogTitle>Détails produit</DialogTitle>
         </DialogHeader>
+        {loading && <p>Chargement...</p>}
+        {error && <p className="text-destructive">{error}</p>}
         {details && (
           <div className="space-y-4">
             <Card>

--- a/frontend/src/components/ScanProductModal.tsx
+++ b/frontend/src/components/ScanProductModal.tsx
@@ -25,7 +25,7 @@ export const ScanProductModal = ({ open, onOpenChange }: ScanProductModalProps) 
   const [product, setProduct] = useState<ProductSummary | null>(null);
   const [isSearching, setIsSearching] = useState(false);
   const [mealType, setMealType] = useState<string>("");
-  const [detailsOpen, setDetailsOpen] = useState(false);
+  const [barcodeDetail, setBarcodeDetail] = useState<string | null>(null);
 
   const units = ["g", "ml", "unité(s)"];
   const mealTypes = ["Petit-déjeuner", "Déjeuner", "Dîner", "Collation"];
@@ -44,6 +44,7 @@ export const ScanProductModal = ({ open, onOpenChange }: ScanProductModalProps) 
     try {
       const found = await fetchProductSummary(barcode.trim());
       setProduct(found);
+      console.log("product", found);
       toast({ title: "Produit trouvé", description: found.name });
     } catch (err) {
       setProduct(null);
@@ -198,7 +199,9 @@ export const ScanProductModal = ({ open, onOpenChange }: ScanProductModalProps) 
                   </div>
                 </div>
                 <div className="text-sm">Nutriscore : {product.nutriscore?.toUpperCase()}</div>
-                <Button variant="link" onClick={() => setDetailsOpen(true)}>Plus de détails</Button>
+                <Button variant="link" onClick={() => setBarcodeDetail(product.barcode)}>
+                  Plus de détails
+                </Button>
               </CardContent>
             </Card>
           )}
@@ -295,11 +298,10 @@ export const ScanProductModal = ({ open, onOpenChange }: ScanProductModalProps) 
           </div>
         </div>
       </DialogContent>
-      {product && (
+      {barcodeDetail && (
         <ProductDetailsModal
-          barcode={product.barcode}
-          open={detailsOpen}
-          onOpenChange={setDetailsOpen}
+          barcode={barcodeDetail}
+          onClose={() => setBarcodeDetail(null)}
         />
       )}
     </Dialog>


### PR DESCRIPTION
## Summary
- store the barcode when opening product details
- log the fetched product summary for debugging
- ensure ProductDetailsModal fetches only when barcode is defined
- add loading/error messages

## Testing
- `npm run lint` *(fails: 6 errors, 10 warnings)*
- `npm run build`
- `pytest -q` *(fails: ModuleNotFoundError: requests et autres)*

------
https://chatgpt.com/codex/tasks/task_e_6883d1436080832596aab92997a30383