### PR TITLE
Ajout du champ barcode dans OFFProduct

### DIFF
--- a/nutriflow/api/router.py
+++ b/nutriflow/api/router.py
@@ -194,6 +194,7 @@ class ProductSummary(BaseModel):
 
 
 class OFFProduct(BaseModel):
+    barcode: str
     name: str
     brand: str
     energy_kcal_per_100g: Optional[float]
@@ -335,6 +336,7 @@ def barcode(data: BarcodeQueryUserInput):
     )
 
     return OFFProduct(
+        barcode=data.barcode,
         name=prod.get("name", ""),
         brand=prod.get("brand", ""),
         energy_kcal_per_100g=_mul(prod.get("energy_kcal_per_100g")),
@@ -364,7 +366,16 @@ def search(
     prod = get_off_search_nutrition(query)
     if not prod:
         raise HTTPException(status_code=404, detail="Produit non trouvé")
-    return OFFProduct(**prod)
+    return OFFProduct(
+        barcode=prod.get("barcode", ""),
+        name=prod.get("name", ""),
+        brand=prod.get("brand", ""),
+        energy_kcal_per_100g=prod.get("energy_kcal_per_100g"),
+        fat_per_100g=prod.get("fat_per_100g"),
+        sugars_per_100g=prod.get("sugars_per_100g"),
+        proteins_per_100g=prod.get("proteins_per_100g"),
+        salt_per_100g=prod.get("salt_per_100g"),
+    )
 
 
 @router.get("/sports", response_model=List[str])

--- a/nutriflow/services.py
+++ b/nutriflow/services.py
@@ -333,6 +333,7 @@ def get_off_search_nutrition(query: str) -> Optional[Dict]:
         p = data["products"][0]
         n = p.get("nutriments", {})
         return {
+            "barcode": p.get("code"),
             "name": p.get("product_name", "Inconnu"),
             "brand": p.get("brands", "Inconnue"),
             "energy_kcal_per_100g": n.get("energy-kcal_100g"),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -252,12 +252,14 @@ def test_barcode_unit(monkeypatch):
     assert isinstance(resp, OFFProduct)
     assert resp.name == "TestProduct"
     assert resp.energy_kcal_per_100g == 50
+    assert resp.barcode == "12345678"
 
 
 def test_search_unit():
     resp = router.search(query="yogurt")
     assert isinstance(resp, OFFProduct)
     assert resp.energy_kcal_per_100g == 100
+    assert resp.barcode == "12345678"
 
 
 def test_product_details_unit():
@@ -394,7 +396,7 @@ def test_barcode_integration_structure(monkeypatch):
                 data = res.json()
                 assert all(
                     field in data
-                    for field in ("name", "brand", "energy_kcal_per_100g")
+                    for field in ("barcode", "name", "brand", "energy_kcal_per_100g")
                 )
 
     run_async(inner())
@@ -408,7 +410,7 @@ def test_search_integration_structure():
             assert res.status_code in (200, 404)
             if res.status_code == 200:
                 data = res.json()
-                assert "name" in data and "energy_kcal_per_100g" in data
+                assert "barcode" in data and "name" in data and "energy_kcal_per_100g" in data
 
     run_async(inner())
 


### PR DESCRIPTION
## Résumé
- ajout du champ `barcode` dans le modèle `OFFProduct`
- renvoi du code-barres dans l'endpoint `/barcode`
- exposition du code-barres aussi via `/search`
- mise à jour de la fonction `get_off_search_nutrition`
- adaptation des tests unitaires

## Résultats des tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d4d1f5c48325bc8595b1c7eb88a6