### PR TITLE
Fix ingredient list rendering in product modal

### DIFF
--- a/frontend/src/components/ProductDetailsModal.tsx
+++ b/frontend/src/components/ProductDetailsModal.tsx
@@ -106,9 +106,13 @@ export const ProductDetailsModal = ({ barcode, onClose }: ProductDetailsModalPro
                 )}
                 {details.ingredients_list && details.ingredients_list.length > 0 && (
                   <ul className="list-disc list-inside text-sm space-y-1">
-                    {details.ingredients_list.map((ing) => (
-                      <li key={ing}>{ing}</li>
-                    ))}
+                    {details.ingredients_list.map((ing, idx) => {
+                      const text = typeof ing === 'string' ? ing : ing.text ?? ''
+                      const key = typeof ing === 'string' ? ing : ing.id ?? idx
+                      return (
+                        <li key={key}>{text}</li>
+                      )
+                    })}
                   </ul>
                 )}
               </CardContent>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -249,16 +249,22 @@ export interface ProductSummary {
   nutriscore?: string;
 }
 
+export interface IngredientItem {
+  id?: string
+  text?: string
+  [key: string]: any
+}
+
 export interface ProductDetails extends ProductSummary {
-  quantity?: string;
-  serving_size?: string;
-  categories?: string;
-  labels_tags?: string;
-  additives_tags?: string;
-  allergens_tags?: string;
-  traces_tags?: string;
-  ingredients_text_fr?: string;
-  ingredients_list?: string[];
+  quantity?: string
+  serving_size?: string
+  categories?: string
+  labels_tags?: string
+  additives_tags?: string
+  allergens_tags?: string
+  traces_tags?: string
+  ingredients_text_fr?: string
+  ingredients_list?: Array<string | IngredientItem>
   packaging?: string;
   countries?: string;
   manufacturing_places?: string;


### PR DESCRIPTION
## Summary
- update ProductDetails type to support ingredient objects
- render ingredient list items using text property and unique key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883dd8d0bc4832581f1d57463e0e9e9