### PR TITLE
Add animated product details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .env
 ;
 frontend/node_modules/
+frontend/dist/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,6 +43,7 @@
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.3.0",
+        "framer-motion": "^12.23.9",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
@@ -4701,6 +4702,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.9",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.9.tgz",
+      "integrity": "sha512-TqEHXj8LWfQSKqfdr5Y4mYltYLw96deu6/K9kGDd+ysqRJPNwF9nb5mZcrLmybHbU7gcJ+HQar41U3UTGanbbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.9",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5659,6 +5687,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.9",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.9.tgz",
+      "integrity": "sha512-6Sv++iWS8XMFCgU1qwKj9l4xuC47Hp4+2jvPfyTXkqDg2tTzSgX6nWKD4kNFXk0k7llO59LZTPuJigza4A2K1A==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,6 +48,7 @@
     "embla-carousel-react": "^8.3.0",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
+    "framer-motion": "^12.23.9",
     "next-themes": "^0.3.0",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",

--- a/frontend/src/components/ProductDetailCard.tsx
+++ b/frontend/src/components/ProductDetailCard.tsx
@@ -1,4 +1,12 @@
+import { useState } from "react";
+import { motion } from "framer-motion";
 import { BadgeCheck, AlertCircle, Leaf, Milk, Wheat, Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { ProductDetails } from "@/services/api";
 
 interface ProductDetailCardProps {
@@ -8,11 +16,69 @@ interface ProductDetailCardProps {
 export function ProductDetailCard({ product }: ProductDetailCardProps) {
   if (!product) return null;
 
+  const [openScore, setOpenScore] = useState<string | null>(null);
+
   const labels = product.labels_tags?.split(",").filter(Boolean) ?? [];
   const allergens = product.allergens_tags?.split(",").filter(Boolean) ?? [];
 
+  const getFlag = (country?: string) => {
+    if (!country) return "";
+    const map: Record<string, string> = {
+      France: "🇫🇷",
+      Belgique: "🇧🇪",
+      Luxembourg: "🇱🇺",
+      "États-Unis": "🇺🇸",
+      Italie: "🇮🇹",
+      Espagne: "🇪🇸",
+    };
+    return map[country.trim()] ?? "";
+  };
+
+  const scores = [
+    {
+      type: "nutriscore",
+      value: product.nutriscore_grade?.toUpperCase(),
+      color: "bg-yellow-400",
+      desc: "Le NutriScore évalue la qualité nutritionnelle globale d’un aliment (A à E).",
+      img: product.nutriscore_grade
+        ? `/nutriscore/${product.nutriscore_grade}.svg`
+        : undefined,
+      label: "NutriScore",
+    },
+    {
+      type: "ecoscore",
+      value: product.ecoscore_grade?.toUpperCase(),
+      color: "bg-green-300",
+      desc: "L’EcoScore renseigne sur l’impact environnemental du produit (A à E).",
+      img: product.ecoscore_grade
+        ? `/ecoscore/${product.ecoscore_grade}.svg`
+        : undefined,
+      label: "EcoScore",
+    },
+    {
+      type: "nova",
+      value: product.nova_group?.toString(),
+      color: "bg-blue-300",
+      desc: "Le groupe NOVA indique le niveau de transformation (1 = brut, 4 = ultra-transformé).",
+      img: product.nova_group ? `/nova/${product.nova_group}.svg` : undefined,
+      label: "NOVA",
+    },
+  ];
+
+  const countries = product.countries
+    ? product.countries.split(",").map((c) => c.trim())
+    : [];
+
   return (
-    <div className="bg-white p-6 rounded-2xl shadow-lg max-w-xl mx-auto">
+    <motion.div
+      initial={{ opacity: 0, scale: 0.97, y: 40 }}
+      animate={{ opacity: 1, scale: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: "easeOut" }}
+      className="bg-white p-6 rounded-2xl shadow-lg max-w-xl mx-auto"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Détails produit ${product.name}`}
+    >
       <div className="flex flex-col items-center gap-2">
         {product.image_url && (
           <img
@@ -43,12 +109,32 @@ export function ProductDetailCard({ product }: ProductDetailCardProps) {
         )}
         {product.manufacturing_places && (
           <div>
-            <span className="font-semibold">Fabriqué à :</span> {product.manufacturing_places}
+            <span className="font-semibold">Fabriqué à :</span>
+            {product.manufacturing_places.includes("France") ? (
+              <span
+                className="text-green-600 font-semibold ml-1"
+                aria-label="Fabriqué en France"
+              >
+                🇫🇷 {product.manufacturing_places}
+              </span>
+            ) : (
+              <span className="ml-1">{product.manufacturing_places}</span>
+            )}
           </div>
         )}
-        {product.countries && (
+        {countries.length > 0 && (
           <div>
-            <span className="font-semibold">Pays :</span> {product.countries}
+            <span className="font-semibold">Pays :</span>
+            {countries.map((c, i) => (
+              <span
+                key={i}
+                className="inline-flex items-center gap-1 ml-2"
+                aria-label={`Pays : ${c}`}
+              >
+                <span>{getFlag(c)}</span>
+                <span>{c}</span>
+              </span>
+            ))}
           </div>
         )}
       </div>
@@ -88,47 +174,73 @@ export function ProductDetailCard({ product }: ProductDetailCardProps) {
         )}
       </div>
 
-      <div className="flex gap-3 mt-4 items-center">
-        {product.nutriscore_grade && (
-          <img
-            src={`/nutriscore/${product.nutriscore_grade}.svg`}
-            alt={`NutriScore ${product.nutriscore_grade.toUpperCase()}`}
-            className="h-10"
-          />
-        )}
-        {product.ecoscore_grade && (
-          <img
-            src={`/ecoscore/${product.ecoscore_grade}.svg`}
-            alt={`EcoScore ${product.ecoscore_grade.toUpperCase()}`}
-            className="h-10"
-          />
-        )}
-        {product.nova_group && (
-          <img
-            src={`/nova/${product.nova_group}.svg`}
-            alt={`NOVA ${product.nova_group}`}
-            className="h-10"
-          />
-        )}
-      </div>
+      {/* Scores avec tooltip */}
+      <TooltipProvider delayDuration={200}>
+        <div className="flex gap-3 mt-4 items-center">
+          {scores.map(
+            (s) =>
+              s.value && (
+                <motion.button
+                  whileTap={{ scale: 0.92 }}
+                  whileHover={{ scale: 1.08 }}
+                  transition={{ type: "spring", stiffness: 400, damping: 17 }}
+                  key={s.type}
+                  className={`relative px-3 py-1 rounded-lg font-bold shadow-sm cursor-pointer ${s.color} focus:outline-blue-400`}
+                  aria-label={s.label}
+                  tabIndex={0}
+                  onMouseEnter={() => setOpenScore(s.type)}
+                  onMouseLeave={() => setOpenScore(null)}
+                  onFocus={() => setOpenScore(s.type)}
+                  onBlur={() => setOpenScore(null)}
+                  onClick={() => setOpenScore(openScore === s.type ? null : s.type)}
+                >
+                  {s.img ? (
+                    <img src={s.img} alt={s.label} className="h-7 inline" />
+                  ) : (
+                    s.value
+                  )}
+                  <span className="ml-1">{s.value}</span>
+                  {openScore === s.type && (
+                    <motion.div
+                      initial={{ opacity: 0, y: 6 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: 6 }}
+                      className="absolute left-1/2 -translate-x-1/2 top-12 z-10 min-w-[180px] bg-white border border-gray-200 text-gray-800 rounded-xl p-2 text-xs shadow-lg"
+                    >
+                      <div className="flex items-center gap-2 mb-1">
+                        <Info className="h-4 w-4 text-blue-400" />
+                        <b>{s.label}</b>
+                      </div>
+                      <div>{s.desc}</div>
+                    </motion.div>
+                  )}
+                </motion.button>
+              )
+          )}
+        </div>
+      </TooltipProvider>
 
       {/* Labels */}
       {labels.length > 0 && (
-        <div className="flex flex-wrap gap-2 mt-3">
+        <motion.div className="flex flex-wrap gap-2 mt-3">
           {labels.map((l, i) => (
-            <span
+            <motion.span
               key={i}
+              initial={{ opacity: 0, scale: 0.6 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ delay: 0.05 * i }}
               className="bg-green-100 text-green-700 px-2 py-1 rounded flex items-center gap-1 text-xs"
+              aria-label={`Label ${l.trim()}`}
             >
               <BadgeCheck className="h-4 w-4" /> {l.trim()}
-            </span>
+            </motion.span>
           ))}
-        </div>
+        </motion.div>
       )}
 
       {/* Allergens */}
       {allergens.length > 0 && (
-        <div className="flex flex-wrap gap-2 mt-2">
+        <motion.div className="flex flex-wrap gap-2 mt-2">
           {allergens.map((a, i) => {
             let icon: React.ReactNode = <AlertCircle className="h-4 w-4" />;
             const al = a.toLowerCase();
@@ -137,15 +249,19 @@ export function ProductDetailCard({ product }: ProductDetailCardProps) {
             if (al.includes("egg")) icon = <Info className="h-4 w-4" />;
             if (al.includes("vegan")) icon = <Leaf className="h-4 w-4" />;
             return (
-              <span
+              <motion.span
                 key={i}
+                initial={{ opacity: 0, scale: 0.7 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ delay: 0.1 + 0.05 * i }}
                 className="bg-orange-100 text-orange-700 px-2 py-1 rounded flex items-center gap-1 text-xs"
+                aria-label={`Allergène ${a.trim()}`}
               >
                 {icon} {a.trim()}
-              </span>
+              </motion.span>
             );
           })}
-        </div>
+        </motion.div>
       )}
 
       {/* Ingrédients */}
@@ -189,9 +305,10 @@ export function ProductDetailCard({ product }: ProductDetailCardProps) {
         target="_blank"
         rel="noopener"
         className="block mt-6 px-4 py-2 bg-blue-100 text-blue-800 font-semibold rounded-xl text-center hover:bg-blue-200 transition"
+        aria-label="Voir sur OpenFoodFacts"
       >
         Voir sur OpenFoodFacts
       </a>
-    </div>
+    </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- enhance ProductDetailCard with motion animations
- show tooltips on nutrition scores
- display country flags and highlight French manufacturing
- animate badge appearance
- add accessibility labels
- ignore frontend build output
- install framer-motion

## Testing
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884941c059883259cb4932ceaf22637