### PR TITLE
Refonte cartes dashboard

### DIFF
--- a/frontend/src/components/DashboardCard.tsx
+++ b/frontend/src/components/DashboardCard.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import { ReactNode } from "react";
 
 interface DashboardCardProps {
@@ -8,15 +9,17 @@ interface DashboardCardProps {
   icon?: ReactNode;
   variant?: "default" | "calories" | "protein" | "carbs" | "fat";
   trend?: "up" | "down" | "neutral";
+  loading?: boolean;
 }
 
-export const DashboardCard = ({ 
-  title, 
-  value, 
-  subtitle, 
-  icon, 
+export const DashboardCard = ({
+  title,
+  value,
+  subtitle,
+  icon,
   variant = "default",
-  trend = "neutral" 
+  trend = "neutral",
+  loading = false,
 }: DashboardCardProps) => {
   const getVariantClasses = () => {
     switch (variant) {
@@ -48,16 +51,25 @@ export const DashboardCard = ({
         {icon && <div className="text-muted-foreground">{icon}</div>}
       </CardHeader>
       <CardContent>
-        <div className="flex items-baseline space-x-2">
-          <div className="text-2xl font-bold text-foreground">{value}</div>
-          {trend !== "neutral" && (
-            <span className={`text-xs ${trend === "up" ? "text-success" : "text-warning"}`}>
-              {getTrendIcon()}
-            </span>
-          )}
-        </div>
-        {subtitle && (
-          <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
+        {loading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-6 w-20" />
+            {subtitle && <Skeleton className="h-4 w-24" />}
+          </div>
+        ) : (
+          <>
+            <div className="flex items-baseline space-x-2">
+              <div className="text-2xl font-bold text-foreground">{value}</div>
+              {trend !== "neutral" && (
+                <span className={`text-xs ${trend === "up" ? "text-success" : "text-warning"}`}>
+                  {getTrendIcon()}
+                </span>
+              )}
+            </div>
+            {subtitle && (
+              <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
+            )}
+          </>
         )}
       </CardContent>
     </Card>

--- a/frontend/src/components/QuickActions.tsx
+++ b/frontend/src/components/QuickActions.tsx
@@ -1,4 +1,6 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { format } from "date-fns";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Plus, UtensilsCrossed, Dumbbell, Scan, List } from "lucide-react";
@@ -13,11 +15,24 @@ export const QuickActions = ({}: QuickActionsProps) => {
   const [addMealOpen, setAddMealOpen] = useState(false);
   const [addActivityOpen, setAddActivityOpen] = useState(false);
   const [scanProductOpen, setScanProductOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const today = format(new Date(), "yyyy-MM-dd");
+
+  const refreshSummary = () =>
+    queryClient.invalidateQueries({ queryKey: ["daily-summary", today] });
 
   return (
     <>
-      <AddMealModal open={addMealOpen} onOpenChange={setAddMealOpen} />
-      <AddActivityModal open={addActivityOpen} onOpenChange={setAddActivityOpen} />
+      <AddMealModal
+        open={addMealOpen}
+        onOpenChange={setAddMealOpen}
+        onAdded={refreshSummary}
+      />
+      <AddActivityModal
+        open={addActivityOpen}
+        onOpenChange={setAddActivityOpen}
+        onSaved={refreshSummary}
+      />
       <ScanProductModal open={scanProductOpen} onOpenChange={setScanProductOpen} />
     <Card className="shadow-soft">
       <CardHeader>

--- a/frontend/src/hooks/use-daily-summary.ts
+++ b/frontend/src/hooks/use-daily-summary.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchDailySummary, type DailySummary } from "@/services/api";
+import { format } from "date-fns";
+
+export function useDailySummary(date?: string, enabled = true) {
+  const finalDate = date ?? format(new Date(), "yyyy-MM-dd");
+  return useQuery<DailySummary>({
+    queryKey: ["daily-summary", finalDate],
+    queryFn: () => fetchDailySummary(finalDate),
+    enabled,
+    staleTime: 1000 * 60,
+  });
+}


### PR DESCRIPTION
## Summary
- met en place `useDailySummary` pour récupérer le bilan du jour
- ajoute un loader dans `DashboardCard`
- rafraîchit le résumé quotidien après ajout/suppression de repas ou d'activité
- consomme les données réelles sur la page d'accueil

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884b85ba9708325b5f66c94dde5acde