### PR TITLE
feat: add macro goals in daily summary

### DIFF
--- a/nutriflow/services.py
+++ b/nutriflow/services.py
@@ -499,3 +499,33 @@ def calculer_tdee(
     print(f"🏋️ Calories brûlées via sport : {calories_sport:.0f} kcal")
     print(f"📊 TDEE total journalier estimé : {tdee:.0f} kcal")
     return tdee
+
+
+def calculate_calorie_goal(tdee: Optional[float], objectif: Optional[str]) -> Optional[float]:
+    """Calcule l'objectif calorique selon l'objectif utilisateur."""
+    if tdee is None:
+        return None
+    obj = (objectif or "maintien").lower()
+    if obj == "perte":
+        goal = tdee - 500
+    elif obj == "prise":
+        goal = tdee + 300
+    else:
+        goal = tdee
+    return round(goal)
+
+
+def calculate_macro_goals(poids_kg: Optional[float], calories_goal: Optional[float]) -> Dict[str, Optional[float]]:
+    """Calcule les objectifs journaliers de protéines, lipides et glucides."""
+    if not poids_kg or not calories_goal:
+        return {"proteins": None, "carbs": None, "fats": None}
+
+    proteins = 1.6 * poids_kg
+    fats = calories_goal * 0.25 / 9
+    carbs = (calories_goal - proteins * 4 - fats * 9) / 4
+
+    return {
+        "proteins": round(proteins),
+        "carbs": round(carbs),
+        "fats": round(fats),
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -25,6 +25,7 @@ from nutriflow.api.router import (
     BMRResponse,
     TDEResponse,
     DailySummary,
+    DailyNutritionSummary,
     UserProfile,
     UserProfileUpdate,
 )
@@ -298,8 +299,15 @@ def test_tdee_unit():
 
 def test_daily_summary_unit():
     resp = router.daily_summary(date_str="2023-01-02")
-    assert isinstance(resp, DailySummary)
-    assert resp.date == "2023-01-02"
+    assert isinstance(resp, DailyNutritionSummary)
+    assert resp.calories_goal == 1800
+    assert resp.calories_consumed == 0
+    expected_prot = round(1.6 * SAMPLE_USER["poids_kg"])
+    expected_fat = round(1800 * 0.25 / 9)
+    expected_carb = round((1800 - expected_prot * 4 - expected_fat * 9) / 4)
+    assert resp.proteins_goal == expected_prot
+    assert resp.fats_goal == expected_fat
+    assert resp.carbs_goal == expected_carb
 
 
 def test_history_unit():
@@ -425,12 +433,14 @@ def test_daily_summary_integration_structure():
             assert all(
                 k in data
                 for k in (
-                    "date",
-                    "calories_apportees",
-                    "calories_brulees",
-                    "tdee",
-                    "balance_calorique",
-                    "conseil",
+                    "calories_consumed",
+                    "calories_goal",
+                    "proteins_consumed",
+                    "proteins_goal",
+                    "carbs_consumed",
+                    "carbs_goal",
+                    "fats_consumed",
+                    "fats_goal",
                 )
             )
 


### PR DESCRIPTION
## Summary
- compute calorie target from TDEE and user goal
- expose macro consumption and targets in `/api/daily-summary`
- cover new endpoint structure with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68963745cb588325acf7cd498f83b719