### PR TITLE
feat: connect meals page to backend

### DIFF
--- a/frontend/src/components/AddMealModal.tsx
+++ b/frontend/src/components/AddMealModal.tsx
@@ -22,6 +22,8 @@ interface AddMealModalProps {
   onOpenChange: (open: boolean) => void;
   /** Type de repas pré-sélectionné lors de l'ouverture */
   defaultType?: string;
+  /** Date du repas au format YYYY-MM-DD */
+  date?: string;
   /** Callback appelé après l'ajout réussi d'un repas */
   onAdded?: () => void;
 }
@@ -30,6 +32,7 @@ export const AddMealModal = ({
   open,
   onOpenChange,
   defaultType,
+  date,
   onAdded,
 }: AddMealModalProps) => {
   const { toast } = useToast();
@@ -99,7 +102,7 @@ export const AddMealModal = ({
       .join(", ");
 
     try {
-      const result = await analyzeIngredients(query, mealType);
+      const result = await analyzeIngredients(query, mealType, date);
       setTotals(result.totals);
       console.log("Résumé nutritionnel :", result.totals);
       toast({

--- a/frontend/src/components/MealList.tsx
+++ b/frontend/src/components/MealList.tsx
@@ -13,13 +13,16 @@ import {
   fetchDailySummary,
   type Meal,
 } from "@/services/api";
+import { useSearchParams } from "react-router-dom";
 import { EditMealModal } from "./EditMealModal";
 import { AddMealModal } from "./AddMealModal";
 
 export const MealList = () => {
   const { toast } = useToast();
   const today = format(new Date(), "yyyy-MM-dd");
-  const [selectedDate, setSelectedDate] = useState<string>(today);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialDate = searchParams.get("date_str") || today;
+  const [selectedDate, setSelectedDate] = useState<string>(initialDate);
   const [meals, setMeals] = useState<Meal[]>([]);
   const [editingMeal, setEditingMeal] = useState<Meal | null>(null);
   const [addMealOpen, setAddMealOpen] = useState(false);
@@ -45,6 +48,19 @@ export const MealList = () => {
   useEffect(() => {
     loadMeals();
   }, [selectedDate]);
+
+  useEffect(() => {
+    const param = searchParams.get("date_str");
+    if (param && param !== selectedDate) {
+      setSelectedDate(param);
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (searchParams.get("date_str") !== selectedDate) {
+      setSearchParams({ date_str: selectedDate });
+    }
+  }, [selectedDate, searchParams, setSearchParams]);
 
   const handleDeleteMeal = async (mealId: string) => {
     if (!confirm("Supprimer ce repas ?")) return;
@@ -102,6 +118,7 @@ export const MealList = () => {
           if (!o) setAddMealType(undefined);
         }}
         defaultType={addMealType}
+        date={selectedDate}
         onAdded={() => {
           loadMeals();
           queryClient.invalidateQueries({

--- a/frontend/src/pages/Meals.tsx
+++ b/frontend/src/pages/Meals.tsx
@@ -1,6 +1,12 @@
-import { SidebarProvider, SidebarTrigger, SidebarInset } from "@/components/ui/sidebar";
+import {
+  SidebarProvider,
+  SidebarTrigger,
+  SidebarInset,
+} from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/AppSidebar";
 import { MealList } from "@/components/MealList";
+import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
 
 const Meals = () => (
   <SidebarProvider>
@@ -11,8 +17,13 @@ const Meals = () => (
           <div className="flex h-16 items-center gap-4 px-6">
             <SidebarTrigger />
             <div className="flex-1">
-              <h1 className="text-2xl font-bold bg-gradient-primary bg-clip-text text-transparent">Mes repas</h1>
+              <h1 className="text-2xl font-bold bg-gradient-primary bg-clip-text text-transparent">
+                Mes repas
+              </h1>
             </div>
+            <Button asChild variant="outline">
+              <Link to="/">Retour</Link>
+            </Button>
           </div>
         </header>
         <main className="flex-1 space-y-6 p-6">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -56,19 +56,27 @@ export async function fetchUnits(): Promise<UnitMapping> {
   return (await res.json()) as UnitMapping;
 }
 
-export async function analyzeIngredients(input: string, mealType: string): Promise<NutritionixResponse> {
-  console.log('Données envoyées :', { query: input, type: mealType });
-  const res = await fetch('http://localhost:8000/api/ingredients', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query: input, type: mealType })
+export async function analyzeIngredients(
+  input: string,
+  mealType: string,
+  date?: string
+): Promise<NutritionixResponse> {
+  console.log("Données envoyées :", {
+    query: input,
+    type: mealType,
+    date_str: date,
+  });
+  const res = await fetch("http://localhost:8000/api/ingredients", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query: input, type: mealType, date_str: date }),
   });
   if (!res.ok) {
     const text = await res.text();
     throw new Error(`Erreur API ${res.status}: ${text}`);
   }
   const data = (await res.json()) as NutritionixResponse;
-  console.log('Réponse reçue :', data);
+  console.log("Réponse reçue :", data);
   return data;
 }
 
@@ -94,7 +102,9 @@ export interface Meal {
 }
 
 export async function fetchMeals(date: string): Promise<Meal[]> {
-  const res = await fetch(`http://localhost:8000/api/meals?date=${date}`);
+  const res = await fetch(
+    `http://localhost:8000/api/meals?date_str=${date}`
+  );
   if (!res.ok) {
     const text = await res.text();
     throw new Error(`Erreur API ${res.status}: ${text}`);


### PR DESCRIPTION
## Summary
- fetch meals with `date_str` query parameter
- allow adding meals for selected date and update URL search params
- add return button to dashboard from meals page

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896f355e3c483258949f198f4c431d9