### PR TITLE
feat: add responsive bottom navigation

### DIFF
--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -9,7 +9,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-const navigation = [
+export const navigation = [
   { title: "Dashboard", url: "/", icon: Home },
   { title: "Repas", url: "/meals", icon: UtensilsCrossed },
   { title: "Activités", url: "/activities", icon: Activity },
@@ -20,7 +20,7 @@ const navigation = [
 
 export function AppSidebar() {
   return (
-    <aside className="w-56 bg-white border-r border-gray-200 p-4 flex flex-col gap-4">
+    <aside className="hidden md:flex w-56 bg-white border-r border-gray-200 p-4 flex-col gap-4">
       <div className="flex items-center gap-2 mb-4">
         <div className="w-8 h-8 bg-gradient-primary rounded-lg flex items-center justify-center">
           <UtensilsCrossed

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,0 +1,26 @@
+import { NavLink } from "react-router-dom";
+import { navigation } from "@/components/AppSidebar";
+import { cn } from "@/lib/utils";
+
+export function BottomNav() {
+  return (
+    <nav className="fixed bottom-0 w-full h-16 flex md:hidden bg-white border-t border-gray-200 justify-around items-center z-50">
+      {navigation.map((item) => (
+        <NavLink
+          key={item.title}
+          to={item.url}
+          className={({ isActive }) =>
+            cn(
+              "flex flex-col items-center text-sm text-gray-600",
+              isActive && "text-primary"
+            )
+          }
+          aria-label={item.title}
+        >
+          <item.icon className="w-5 h-5" aria-hidden="true" />
+          <span className="text-xs">{item.title}</span>
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/pages/Activities.tsx
+++ b/frontend/src/pages/Activities.tsx
@@ -1,4 +1,5 @@
 import { AppSidebar } from "@/components/AppSidebar";
+import { BottomNav } from "@/components/BottomNav";
 import { ActivityList } from "@/components/ActivityList";
 
 const Activities = () => (
@@ -10,10 +11,11 @@ const Activities = () => (
           <h1 className="text-2xl font-bold bg-gradient-primary bg-clip-text text-transparent">Mes activités</h1>
         </div>
       </header>
-      <main className="flex-1 space-y-6 p-6">
+      <main className="flex-1 space-y-6 p-6 pb-24 md:pb-6">
         <ActivityList />
       </main>
     </div>
+    <BottomNav />
   </div>
 );
 

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -1,5 +1,6 @@
 import { format } from "date-fns";
 import { AppSidebar } from "@/components/AppSidebar";
+import { BottomNav } from "@/components/BottomNav";
 import { DashboardCard } from "@/components/DashboardCard";
 import { MacroProgress } from "@/components/MacroProgress";
 import { QuickActions } from "@/components/QuickActions";
@@ -36,7 +37,7 @@ const Index = () => {
           </div>
         </header>
 
-        <main className="flex-1 space-y-6 p-6">
+        <main className="flex-1 space-y-6 p-6 pb-24 md:pb-6">
             {/* Hero Section */}
             <div className="relative overflow-hidden rounded-xl shadow-strong">
               <img 
@@ -120,6 +121,7 @@ const Index = () => {
             </Card>
         </main>
       </div>
+      <BottomNav />
     </div>
   );
 };

--- a/frontend/src/pages/Meals.tsx
+++ b/frontend/src/pages/Meals.tsx
@@ -1,4 +1,5 @@
 import { AppSidebar } from "@/components/AppSidebar";
+import { BottomNav } from "@/components/BottomNav";
 import { MealList } from "@/components/MealList";
 import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
@@ -18,10 +19,11 @@ const Meals = () => (
           </Button>
         </div>
       </header>
-      <main className="flex-1 space-y-6 p-6">
+      <main className="flex-1 space-y-6 p-6 pb-24 md:pb-6">
         <MealList />
       </main>
     </div>
+    <BottomNav />
   </div>
 );
 

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { BottomNav } from "@/components/BottomNav";
 
 const NotFound = () => {
   const location = useLocation();
@@ -20,6 +21,7 @@ const NotFound = () => {
           Return to Home
         </a>
       </div>
+      <BottomNav />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- hide sidebar on mobile and export shared navigation links
- add fixed bottom navigation for mobile devices
- integrate bottom nav and padding across main pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npx eslint src/components/BottomNav.tsx src/components/AppSidebar.tsx src/pages/Index.tsx src/pages/Meals.tsx src/pages/Activities.tsx src/pages/NotFound.tsx`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896ffbe56748325b647fc255f507ada