### PR TITLE
feat: calcul du TDEE selon l'objectif utilisateur

### DIFF
--- a/nutriflow/services.py
+++ b/nutriflow/services.py
@@ -490,18 +490,27 @@ def calculer_bmr(poids_kg: float, taille_cm: float, age: int, sexe: str) -> floa
 
 
 def calculer_tdee(
-    poids_kg: float, taille_cm: float, age: int, sexe: str, calories_sport: float = 0.0
+    poids_kg: float, taille_cm: float, age: int, sexe: str, facteur_activite: float
 ) -> float:
     """
-    Calcule le TDEE = BMR + calories_sportives.
-    Affiche un résumé clair des valeurs.
+    Calcule le TDEE de base = BMR * facteur d'activité.
     """
     bmr = calculer_bmr(poids_kg, taille_cm, age, sexe)
-    tdee = bmr + calories_sport
+    tdee_base = bmr * facteur_activite
     print(f"🧬 BMR (Métabolisme de base) : {bmr:.0f} kcal")
-    print(f"🏋️ Calories brûlées via sport : {calories_sport:.0f} kcal")
-    print(f"📊 TDEE total journalier estimé : {tdee:.0f} kcal")
-    return tdee
+    print(f"⚙️ Facteur d'activité : {facteur_activite}")
+    print(f"📊 TDEE de base estimé : {tdee_base:.0f} kcal")
+    return tdee_base
+
+
+def ajuster_tdee(tdee_base: float, goal: str) -> float:
+    """Ajuste le TDEE en fonction de l'objectif (perte, maintien, prise)."""
+    g = (goal or "maintien").lower()
+    if g == "perte":
+        return tdee_base * 0.8
+    if g == "prise":
+        return tdee_base * 1.15
+    return tdee_base
 
 
 def calculate_calorie_goal(tdee: Optional[float], objectif: Optional[str]) -> Optional[float]:

--- a/tests/test_aggregate_daily_summary.py
+++ b/tests/test_aggregate_daily_summary.py
@@ -8,7 +8,14 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import nutriflow.db.supabase as db
 import nutriflow.services as services
 
-SAMPLE_USER = {"poids_kg": 70.0, "taille_cm": 175.0, "age": 30, "sexe": "male", "objectif": "maintien"}
+SAMPLE_USER = {
+    "poids_kg": 70.0,
+    "taille_cm": 175.0,
+    "age": 30,
+    "sexe": "male",
+    "activity_factor": 1.2,
+    "goal": "maintien",
+}
 
 class DummyTable:
     def __init__(self, store):
@@ -31,7 +38,7 @@ def common_patches(monkeypatch):
     monkeypatch.setattr(db, "get_supabase_client", lambda: DummyClient(inserted))
     monkeypatch.setattr(db, "get_user", lambda uid: SAMPLE_USER)
     monkeypatch.setattr(services, "calculer_bmr", lambda p, t, a, s: 1500.0)
-    monkeypatch.setattr(services, "calculer_tdee", lambda p, t, a, s, c: 1500.0 + c)
+    monkeypatch.setattr(services, "calculer_tdee", lambda p, t, a, s, af: 1500.0 * af)
     return inserted
 
 
@@ -48,7 +55,7 @@ def test_aggregate_no_meal_no_activity(common_patches, monkeypatch):
     res = db.aggregate_daily_summary("u", "2023-01-01")
     assert res["calories_apportees"] == 0.0
     assert res["calories_brulees"] == 0.0
-    assert res["balance_calorique"] == -1500.0
+    assert res["balance_calorique"] == -1800.0
     assert inserted and inserted[0]["calories_apportees"] == 0.0
 
 
@@ -64,7 +71,7 @@ def test_aggregate_meals_no_activity(common_patches, monkeypatch):
 
     res = db.aggregate_daily_summary("u", "2023-01-02")
     assert res["calories_apportees"] == 600.0
-    assert res["balance_calorique"] == -900.0
+    assert res["balance_calorique"] == -1200.0
     assert inserted and inserted[0]["prot_tot"] == 30.0
 
 
@@ -81,5 +88,5 @@ def test_aggregate_meals_with_activity(common_patches, monkeypatch):
     res = db.aggregate_daily_summary("u", "2023-01-03")
     assert res["calories_apportees"] == 800.0
     assert res["calories_brulees"] == 200
-    assert res["tdee"] == 1700.0
+    assert res["tdee"] == 2000.0
     assert inserted and inserted[0]["gluc_tot"] == 100.0


### PR DESCRIPTION
## Résumé
- calcule le TDEE de base avec le facteur d'activité et l'ajuste selon l'objectif
- stocke `tdee_base`, `tdee` et le nouveau champ `goal` dans le profil utilisateur
- met à jour la génération du bilan quotidien et les tests associés

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897399fc97883258282dd95e74ac201