### PR TITLE
feat: calcule les objectifs macros quotidiens

### DIFF
--- a/tests/test_macro_objectives.py
+++ b/tests/test_macro_objectives.py
@@ -1,0 +1,47 @@
+import types
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import nutriflow.db.supabase as db
+
+
+class DummyTable:
+    def __init__(self, store):
+        self.store = store
+
+    def update(self, record):
+        self.store.append(record)
+        return self
+
+    def eq(self, *_args, **_kwargs):
+        return self
+
+    def execute(self):
+        return types.SimpleNamespace(data=self.store)
+
+
+class DummyClient:
+    def __init__(self, store):
+        self.store = store
+
+    def table(self, _):
+        return DummyTable(self.store)
+
+
+def test_update_macro_objectives(monkeypatch):
+    store = []
+    monkeypatch.setattr(db, "get_supabase_client", lambda: DummyClient(store))
+    monkeypatch.setattr(db, "get_daily_summary", lambda u, d: {"tdee": 2000.0})
+    monkeypatch.setattr(db, "get_user", lambda uid: {"objectif": "perte"})
+
+    res = db.update_macro_objectives("u", "2023-01-01")
+
+    assert pytest.approx(res["prot_obj"], rel=1e-3) == 150.0
+    assert pytest.approx(res["gluc_obj"], rel=1e-3) == 150.0
+    assert pytest.approx(res["lip_obj"], rel=1e-3) == 88.8889
+
+    assert store and store[0]["prot_obj"] == res["prot_obj"]


### PR DESCRIPTION
## Summary
- calcule les objectifs protéines, glucides et lipides selon le TDEE et l'objectif utilisateur
- stocke ces objectifs dans la table `daily_summary`
- ajoute un test unitaire pour vérifier le calcul

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68978fcfbf148325badf1ab285234ce2