### PR TITLE
feat(frontend): progression des macronutriments colorisée

### DIFF
--- a/frontend/src/components/MacroProgress.tsx
+++ b/frontend/src/components/MacroProgress.tsx
@@ -9,7 +9,14 @@ interface MacroProgressProps {
 export const MacroProgress = ({ protein, carbs, fat }: MacroProgressProps) => {
   const getMacroPercentage = (current: number, target?: number) => {
     if (!target) return 0;
-    return Math.min((current / target) * 100, 100);
+    return (current / target) * 100;
+  };
+
+  const getBarColor = (percentage: number, baseColor: string) => {
+    if (percentage > 120) return "bg-red-500";
+    if (percentage >= 100) return "bg-green-500";
+    if (percentage < 50) return "bg-orange-500";
+    return baseColor;
   };
 
   const macros = [
@@ -18,51 +25,58 @@ export const MacroProgress = ({ protein, carbs, fat }: MacroProgressProps) => {
       current: protein.current,
       target: protein.target,
       color: "bg-nutrition-protein",
-      percentage: getMacroPercentage(protein.current, protein.target)
+      percentage: getMacroPercentage(protein.current, protein.target),
     },
     {
-      name: "Glucides", 
+      name: "Glucides",
       current: carbs.current,
       target: carbs.target,
       color: "bg-nutrition-carbs",
-      percentage: getMacroPercentage(carbs.current, carbs.target)
+      percentage: getMacroPercentage(carbs.current, carbs.target),
     },
     {
       name: "Lipides",
-      current: fat.current, 
+      current: fat.current,
       target: fat.target,
       color: "bg-nutrition-fat",
-      percentage: getMacroPercentage(fat.current, fat.target)
-    }
+      percentage: getMacroPercentage(fat.current, fat.target),
+    },
   ];
 
   return (
     <div className="space-y-4">
       <h3 className="text-lg font-semibold text-foreground">Macronutriments</h3>
-      {macros.map((macro) => (
-        <div key={macro.name} className="space-y-2">
-          <div className="flex justify-between items-center">
-            <span className="text-sm font-medium text-foreground">{macro.name}</span>
-            <span className="text-sm text-muted-foreground">
-              {macro.target ? `${macro.current}g / ${macro.target}g` : `${macro.current}g`}
-            </span>
+      {macros.map((macro) => {
+        const percentage = macro.percentage;
+        const barColor = getBarColor(percentage, macro.color);
+        const width = Math.min(percentage, 100);
+        return (
+          <div key={macro.name} className="space-y-2">
+            <div className="flex justify-between items-center">
+              <span className="text-sm font-medium text-foreground">{macro.name}</span>
+              <span className="text-sm text-muted-foreground">
+                {macro.target
+                  ? `${macro.current.toFixed(1)} / ${macro.target} g`
+                  : `${macro.current.toFixed(1)} g`}
+              </span>
+            </div>
+            {macro.target && (
+              <>
+                <div className="relative">
+                  <Progress value={width} className="h-2" />
+                  <div
+                    className={`absolute top-0 left-0 h-2 rounded-full transition-all duration-500 ${barColor}`}
+                    style={{ width: `${width}%` }}
+                  />
+                </div>
+                <div className="text-xs text-muted-foreground text-right">
+                  {percentage.toFixed(0)}%
+                </div>
+              </>
+            )}
           </div>
-          {macro.target && (
-            <>
-              <div className="relative">
-                <Progress value={macro.percentage} className="h-2" />
-                <div
-                  className={`absolute top-0 left-0 h-2 rounded-full transition-all duration-500 ${macro.color}`}
-                  style={{ width: `${macro.percentage}%` }}
-                />
-              </div>
-              <div className="text-xs text-muted-foreground text-right">
-                {macro.percentage.toFixed(0)}%
-              </div>
-            </>
-          )}
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -15,9 +15,18 @@ const Index = () => {
   const { data: summary, isLoading } = useDailySummary(today);
 
   const macrosData = {
-    protein: { current: summary?.proteins_consumed ?? 0, target: summary?.proteins_goal },
-    carbs: { current: summary?.carbs_consumed ?? 0, target: summary?.carbs_goal },
-    fat: { current: summary?.fats_consumed ?? 0, target: summary?.fats_goal },
+    protein: {
+      current: summary?.prot_tot ?? summary?.proteins_consumed ?? 0,
+      target: summary?.prot_obj ?? summary?.proteins_goal,
+    },
+    carbs: {
+      current: summary?.gluc_tot ?? summary?.carbs_consumed ?? 0,
+      target: summary?.gluc_obj ?? summary?.carbs_goal,
+    },
+    fat: {
+      current: summary?.lip_tot ?? summary?.fats_consumed ?? 0,
+      target: summary?.lip_obj ?? summary?.fats_goal,
+    },
   };
 
   const remainingCalories =

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -254,6 +254,12 @@ export interface DailySummary {
   carbs_goal?: number;
   fats_consumed?: number;
   fats_goal?: number;
+  prot_tot?: number;
+  prot_obj?: number;
+  gluc_tot?: number;
+  gluc_obj?: number;
+  lip_tot?: number;
+  lip_obj?: number;
 }
 
 export async function fetchDailySummary(date: string): Promise<DailySummary> {


### PR DESCRIPTION
## Summary
- affiche la progression des macronutriments via l'API
- met à jour les champs de la synthèse quotidienne
- colorise les barres de progression selon l'atteinte des objectifs

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68979892fdac83258664ce49d7324213