### PR TITLE
UI: affichage des objectifs journaliers avec barres de progression

### DIFF
--- a/frontend/src/components/DashboardCard.tsx
+++ b/frontend/src/components/DashboardCard.tsx
@@ -1,6 +1,9 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Progress } from "@/components/ui/progress";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { Badge } from "@/components/ui/badge";
+import { Info as InfoIcon } from "lucide-react";
 import { ReactNode } from "react";
 
 interface DashboardCardProps {
@@ -13,6 +16,8 @@ interface DashboardCardProps {
   variant?: "default" | "calories" | "protein" | "carbs" | "fat";
   trend?: "up" | "down" | "neutral";
   loading?: boolean;
+  info?: string;
+  badge?: string;
 }
 
 export const DashboardCard = ({
@@ -25,6 +30,8 @@ export const DashboardCard = ({
   variant = "default",
   trend = "neutral",
   loading = false,
+  info,
+  badge,
 }: DashboardCardProps) => {
   const getVariantClasses = () => {
     switch (variant) {
@@ -38,6 +45,21 @@ export const DashboardCard = ({
         return "border-nutrition-fat/20 bg-gradient-to-br from-pink-50 to-pink-100/50";
       default:
         return "border-primary/20 bg-gradient-to-br from-primary/5 to-primary/10";
+    }
+  };
+
+  const getProgressColor = () => {
+    switch (variant) {
+      case "calories":
+        return "bg-nutrition-calories";
+      case "protein":
+        return "bg-nutrition-protein";
+      case "carbs":
+        return "bg-nutrition-carbs";
+      case "fat":
+        return "bg-nutrition-fat";
+      default:
+        return "bg-primary";
     }
   };
 
@@ -58,7 +80,17 @@ export const DashboardCard = ({
         <CardTitle className="text-sm font-medium text-muted-foreground">
           {title}
         </CardTitle>
-        {icon && <div className="text-muted-foreground">{icon}</div>}
+        <div className="flex items-center gap-2 text-muted-foreground">
+          {info && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <InfoIcon className="h-4 w-4 cursor-pointer" aria-label={`info ${title}`} />
+              </TooltipTrigger>
+              <TooltipContent>{info}</TooltipContent>
+            </Tooltip>
+          )}
+          {icon && <div>{icon}</div>}
+        </div>
       </CardHeader>
       <CardContent>
         {loading ? (
@@ -72,7 +104,7 @@ export const DashboardCard = ({
               <div className="text-2xl font-bold text-foreground">
                 {goal !== undefined
                   ? `${Math.round(value)} / ${Math.round(goal)} ${unit ?? ""}`
-                  : `${Math.round(value)} ${unit ?? ""}`}
+                  : `${Math.round(value)} / – ${unit ?? ""}`}
               </div>
               {trend !== "neutral" && (
                 <span className={`text-xs ${trend === "up" ? "text-success" : "text-warning"}`}>
@@ -81,8 +113,14 @@ export const DashboardCard = ({
               )}
             </div>
             {progress !== undefined && (
-              <Progress value={progress} className="h-2" />
+              <Progress
+                value={progress}
+                className="h-2"
+                indicatorClassName={getProgressColor()}
+                aria-label={`progression ${title}`}
+              />
             )}
+            {badge && <Badge className="mt-2">{badge}</Badge>}
             {subtitle && (
               <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
             )}

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -5,8 +5,10 @@ import { cn } from "@/lib/utils"
 
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> & {
+    indicatorClassName?: string
+  }
+>(({ className, value, indicatorClassName, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
@@ -16,7 +18,10 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className={cn(
+        "h-full w-full flex-1 bg-primary transition-all",
+        indicatorClassName
+      )}
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/frontend/src/hooks/use-goals.ts
+++ b/frontend/src/hooks/use-goals.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchGoals, type Goals } from "@/services/api";
+
+export function useGoals(enabled = true) {
+  return useQuery<Goals>({
+    queryKey: ["user-goals"],
+    queryFn: fetchGoals,
+    enabled,
+    staleTime: 1000 * 60,
+  });
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -245,6 +245,31 @@ export async function deleteActivity(activityId: string): Promise<void> {
   }
 }
 
+export interface GoalRatios {
+  prot_pct: number;
+  fat_pct: number;
+  carbs_pct: number;
+}
+
+export interface Goals {
+  target_kcal: number;
+  prot_g: number;
+  fat_g: number;
+  carbs_g: number;
+  ratios: GoalRatios;
+  tdee: number;
+  objectif: string;
+}
+
+export async function fetchGoals(): Promise<Goals> {
+  const res = await fetch('http://localhost:8000/api/user/goals');
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Erreur API ${res.status}: ${text}`);
+  }
+  return (await res.json()) as Goals;
+}
+
 export interface DailySummary {
   calories_consumed?: number;
   calories_goal?: number;

--- a/tests/test_compute_goals.py
+++ b/tests/test_compute_goals.py
@@ -44,3 +44,16 @@ def test_compute_goals_prise():
     assert res["ratios"]["prot_pct"] == pytest.approx(0.25, rel=1e-3)
     assert res["ratios"]["fat_pct"] == pytest.approx(0.225, rel=1e-3)
     assert res["ratios"]["carbs_pct"] == pytest.approx(0.525, rel=1e-3)
+
+
+@pytest.mark.parametrize(
+    "objectif,tdee",
+    [("perte", 1200.0), ("maintien", 900.0), ("prise", 800.0)],
+)
+def test_compute_goals_bounds(objectif: str, tdee: float):
+    user = {**SAMPLE_USER, "objectif": objectif}
+    res = compute_goals(user, tdee)
+    min_prot = 1.8 * SAMPLE_USER["poids_kg"] if objectif != "prise" else 2.0 * SAMPLE_USER["poids_kg"]
+    assert res["prot_g"] >= min_prot
+    assert res["fat_g"] >= 0.8 * SAMPLE_USER["poids_kg"]
+    assert res["carbs_g"] == pytest.approx(0.0)


### PR DESCRIPTION
## Résumé
- ajout du hook `useGoals` et de l'appel API `GET /api/user/goals`
- carte Dashboard enrichie (tooltip, couleurs, badge) pour suivre calories et macros
- test de sécurité sur `compute_goals` garantissant prot/fat minimum et glucides non négatifs

## Tests
- `pytest`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68983f910e5c8325b6039ea7607958b8