### PR TITLE
Gère l'absence de profil utilisateur sur le dashboard

### DIFF
--- a/frontend/src/hooks/use-dashboard-data.ts
+++ b/frontend/src/hooks/use-dashboard-data.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getUserProfile, getDailySummary, type UserProfile, type DailySummary } from '@/api/nutriflow';
 
 export interface DashboardData {
-  profile: UserProfile;
+  profile?: UserProfile;
   summary: DailySummary;
   remainingCalories: number;
   targetCalories: number;
@@ -12,10 +12,14 @@ export function useDashboardData() {
   return useQuery<DashboardData>({
     queryKey: ['dashboard-data'],
     queryFn: async () => {
-      const [profile, summary] = await Promise.all([
-        getUserProfile(),
-        getDailySummary(),
-      ]);
+      let profile: UserProfile | undefined;
+      try {
+        profile = await getUserProfile();
+      } catch (e) {
+        profile = undefined;
+      }
+
+      const summary = await getDailySummary();
       const target = summary.target_calories ?? summary.tdee ?? 0;
       const remaining = target - (summary.calories_apportees ?? 0);
       return { profile, summary, remainingCalories: remaining, targetCalories: target };

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -27,7 +27,7 @@ const goalLabels: Record<string, string> = {
 };
 
 const Index = () => {
-  const { data } = useDashboardData();
+  const { data, error } = useDashboardData();
   const isMobile = useIsMobile();
   const [open, setOpen] = useState(false);
 
@@ -37,9 +37,10 @@ const Index = () => {
   const tdeeTarget = Math.round(data?.targetCalories ?? 0);
   const goalLabel = profile ? goalLabels[profile.goal ?? ''] ?? profile.goal ?? 'Indéfini' : 'Indéfini';
 
-  const macroLine = summary && (summary.target_proteins_g || summary.target_carbs_g || summary.target_fats_g)
-    ? `Protéines : ${summary.target_proteins_g ?? 0} g • Glucides : ${summary.target_carbs_g ?? 0} g • Lipides : ${summary.target_fats_g ?? 0} g`
-    : undefined;
+  const macroLine =
+    summary && (summary.target_proteins_g || summary.target_carbs_g || summary.target_fats_g)
+      ? `Protéines : ${summary.target_proteins_g ?? 0} g • Glucides : ${summary.target_carbs_g ?? 0} g • Lipides : ${summary.target_fats_g ?? 0} g`
+      : undefined;
 
   const dialogContent = (
     <div id="day-ref-content" className="space-y-2">
@@ -53,7 +54,7 @@ const Index = () => {
       {macroLine && <p>{macroLine}</p>}
       <ul className="list-disc list-inside text-sm">
         <li>Le solde = Apports − TDEE</li>
-        <li>Objectif en cours : {goalLabel}</li>
+        <li>Objectif en cours : {goalLabel}</li>
       </ul>
       <p className="text-xs text-muted-foreground">Formule BMR Mifflin-St Jeor. Adaptation TDEE selon objectif.</p>
     </div>
@@ -91,6 +92,12 @@ const Index = () => {
               </div>
             </div>
           </div>
+
+          {error && (
+            <div role="alert" className="rounded-md bg-red-100 p-4 text-red-800">
+              Erreur lors du chargement des données du dashboard.
+            </div>
+          )}
 
           {data && (
             <section className="space-y-4">

--- a/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import Index from '../Index';
-import { vi } from 'vitest';
+import { vi, type Mock } from 'vitest';
 vi.mock('@/components/AppSidebar', () => ({ AppSidebar: () => <div /> }));
 vi.mock('@/components/BottomNav', () => ({ BottomNav: () => <div /> }));
 
@@ -30,6 +30,8 @@ vi.mock('@/api/nutriflow', () => ({
   })),
 }));
 
+import { getUserProfile } from '@/api/nutriflow';
+
 function renderWithClient(ui: React.ReactElement) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
@@ -46,7 +48,7 @@ describe('Dashboard', () => {
         matches: false,
         addEventListener: () => {},
         removeEventListener: () => {},
-      } as any;
+      } as unknown as MediaQueryList;
     };
   });
 
@@ -63,5 +65,12 @@ describe('Dashboard', () => {
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
     fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('affiche les données même si le profil utilisateur est absent', async () => {
+    (getUserProfile as Mock).mockRejectedValueOnce(new Error('not found'));
+    renderWithClient(<Index />);
+    expect(await screen.findByText(/Objectif : Indéfini/i)).toBeInTheDocument();
+    expect(screen.getByText(/Il vous reste 1500 kcal/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Résumé
- évite qu'une erreur sur le profil utilisateur bloque l'affichage du dashboard
- affiche un message d'erreur si les données du jour ne peuvent pas être récupérées
- ajoute un test pour le cas sans profil

## Tests
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6898538ca9e883259dfdbc9d384ca8e2