### PR TITLE
Ajout du on_conflict pour daily_summary

### DIFF
--- a/nutriflow/api/router.py
+++ b/nutriflow/api/router.py
@@ -591,7 +591,8 @@ def get_goals():
                 "target_proteins_g": goals["prot_g"],
                 "target_fats_g": goals["fat_g"],
                 "target_carbs_g": goals["carbs_g"],
-            }
+            },
+            on_conflict=["user_id", "date"],
         ).execute()
     except Exception:
         pass

--- a/nutriflow/db/supabase.py
+++ b/nutriflow/db/supabase.py
@@ -430,7 +430,11 @@ def aggregate_daily_summary(user_id: str, date: str):
     except Exception:
         pass
 
-    supabase.table("daily_summary").upsert(record).execute()
+    # S'assure de mettre à jour l'entrée correspondant au même utilisateur et à la
+    # même date plutôt que de créer une nouvelle ligne partielle.
+    supabase.table("daily_summary").upsert(
+        record, on_conflict=["user_id", "date"]
+    ).execute()
     return record
 
 

--- a/nutriflow/services.py
+++ b/nutriflow/services.py
@@ -590,7 +590,11 @@ def update_daily_summary(user_id: str, date: date) -> Dict:
         }
 
         supabase = db.get_supabase_client()
-        supabase.table("daily_summary").upsert(record).execute()
+        # Utilise on_conflict pour éviter la création de doublons lorsque
+        # la ligne existe déjà pour la même date.
+        supabase.table("daily_summary").upsert(
+            record, on_conflict=["user_id", "date"]
+        ).execute()
     except Exception:
         # En cas d'erreur, on n'interrompt pas le flux principal
         pass

--- a/tests/test_aggregate_daily_summary.py
+++ b/tests/test_aggregate_daily_summary.py
@@ -21,9 +21,12 @@ SAMPLE_USER = {
 class DummyTable:
     def __init__(self, store):
         self.store = store
-    def upsert(self, record):
+
+    def upsert(self, record, **_kwargs):
+        """Ignore les paramètres supplémentaires comme on_conflict."""
         self.store.append(record)
         return self
+
     def execute(self):
         return types.SimpleNamespace(data=self.store)
 


### PR DESCRIPTION
## Résumé
- évite la création d'entrées incomplètes dans `daily_summary`
- met à jour les écritures depuis le service et les routes API
- adapte les tests aux nouveaux paramètres

## Tests
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898625454c08325a127d5d908c2cd7e