### PR TITLE
Configure proxy for Vite dev server

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: { "/api": "http://localhost:8000" },
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- add API proxy to dev server configuration

## Testing
- `npm test -- --run` (fails: Merge conflict marker in Dashboard.test.tsx)
- `npm run lint` (fails: Merge conflict marker in Dashboard.test.tsx)
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68986e69e1f08325aaf75fe20763adc6