### PR TITLE
Aligne le tableau de bord sur DailyNutritionSummary

### DIFF
--- a/frontend/src/api/nutriflow.ts
+++ b/frontend/src/api/nutriflow.ts
@@ -9,16 +9,14 @@ export type UserProfile = {
 };
 
 export type DailySummary = {
-  date: string;
-  calories_apportees: number;
-  calories_brulees: number;
-  tdee: number;
-  balance_calorique: number;
-  conseil: string;
-  target_calories?: number;
-  target_proteins_g?: number;
-  target_carbs_g?: number;
-  target_fats_g?: number;
+  calories_consumed?: number;
+  calories_goal?: number;
+  proteins_consumed?: number;
+  proteins_goal?: number;
+  carbs_consumed?: number;
+  carbs_goal?: number;
+  fats_consumed?: number;
+  fats_goal?: number;
 };
 
 const API = (path: string) => `/api${path}`;

--- a/frontend/src/hooks/use-dashboard-data.ts
+++ b/frontend/src/hooks/use-dashboard-data.ts
@@ -16,8 +16,8 @@ export function useDashboardData() {
       const profile = await getUserProfile();
 
       const summary = await getDailySummary();
-      const target = summary.target_calories ?? summary.tdee ?? 0;
-      const remaining = target - (summary.calories_apportees ?? 0);
+      const target = summary.calories_goal ?? 0;
+      const remaining = target - (summary.calories_consumed ?? 0);
       return { profile, summary, remainingCalories: remaining, targetCalories: target };
     },
     staleTime: 1000 * 60,

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -38,8 +38,8 @@ const Index = () => {
   const goalLabel = profile ? goalLabels[profile.goal ?? ''] ?? profile.goal ?? 'Indéfini' : 'Indéfini';
 
   const macroLine =
-    summary && (summary.target_proteins_g || summary.target_carbs_g || summary.target_fats_g)
-      ? `Protéines : ${summary.target_proteins_g ?? 0} g • Glucides : ${summary.target_carbs_g ?? 0} g • Lipides : ${summary.target_fats_g ?? 0} g`
+    summary && (summary.proteins_goal || summary.carbs_goal || summary.fats_goal)
+      ? `Protéines : ${summary.proteins_goal ?? 0} g • Glucides : ${summary.carbs_goal ?? 0} g • Lipides : ${summary.fats_goal ?? 0} g`
       : undefined;
 
   const dialogContent = (

--- a/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -17,16 +17,14 @@ vi.mock('@/api/nutriflow', () => ({
     tdee: 2200,
   })),
   getDailySummary: vi.fn(async () => ({
-    date: '2024-01-01',
-    calories_apportees: 500,
-    calories_brulees: 0,
-    tdee: 2200,
-    balance_calorique: 0,
-    conseil: 'ok',
-    target_calories: 2000,
-    target_proteins_g: 150,
-    target_carbs_g: 180,
-    target_fats_g: 70,
+    calories_consumed: 500,
+    calories_goal: 2000,
+    proteins_consumed: 0,
+    proteins_goal: 150,
+    carbs_consumed: 0,
+    carbs_goal: 180,
+    fats_consumed: 0,
+    fats_goal: 70,
   })),
 }));
 
@@ -70,12 +68,10 @@ describe('Dashboard', () => {
   });
 
   it('affiche les données même si le profil utilisateur est absent', async () => {
-
     (getUserProfile as Mock).mockResolvedValueOnce(undefined);
-=======
-    (getUserProfile as Mock).mockRejectedValueOnce(new Error('not found'));
-
-
+    renderWithClient(<Index />);
+    expect(await screen.findByText(/Il vous reste 1500 kcal/i)).toBeInTheDocument();
+  });
 
   it("affiche un message d'erreur si le résumé du jour échoue", async () => {
     (getDailySummary as Mock).mockRejectedValueOnce(new Error('fail'));


### PR DESCRIPTION
## Résumé
- adapte `DailySummary` aux champs `DailyNutritionSummary`
- met à jour les hooks et le composant Index pour utiliser `calories_goal` et `calories_consumed`
- ajuste les tests du dashboard avec les nouvelles propriétés

## Tests
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68986e6b9c9083259915184e00ffab4a