### PR TITLE
Mise à jour automatique du bilan quotidien

### DIFF
--- a/nutriflow/db/supabase.py
+++ b/nutriflow/db/supabase.py
@@ -106,6 +106,13 @@ def get_meal_items(meal_id):
     return response.data or []
 
 
+def get_meal_item(item_id):
+    """Récupère un aliment d'un repas par son identifiant."""
+    supabase = get_supabase_client()
+    response = supabase.table("meal_items").select("*").eq("id", item_id).execute()
+    return response.data[0] if response.data else None
+
+
 def get_meal(meal_id):
     """Récupère un repas par son identifiant."""
     supabase = get_supabase_client()

--- a/tests/test_update_daily_summary.py
+++ b/tests/test_update_daily_summary.py
@@ -1,0 +1,90 @@
+import types
+import nutriflow.services as services
+import nutriflow.db.supabase as db
+
+
+def test_update_daily_summary_dynamic(monkeypatch):
+    store = []
+
+    class DummyTable:
+        def __init__(self, store):
+            self.store = store
+            self.filters = {}
+
+        def select(self, *_):
+            return self
+
+        def eq(self, key, value):
+            self.filters[key] = value
+            return self
+
+        def upsert(self, record, **_):
+            for i, rec in enumerate(self.store):
+                if rec["user_id"] == record["user_id"] and rec["date"] == record["date"]:
+                    self.store[i] = record
+                    break
+            else:
+                self.store.append(record)
+            return self
+
+        def execute(self):
+            if self.filters:
+                data = [
+                    r for r in self.store if all(r.get(k) == v for k, v in self.filters.items())
+                ]
+            else:
+                data = self.store
+            return types.SimpleNamespace(data=data)
+
+    class DummyClient:
+        def table(self, _):
+            return DummyTable(store)
+
+    monkeypatch.setattr(db, "get_supabase_client", lambda: DummyClient())
+
+    user = {
+        "poids_kg": 70.0,
+        "taille_cm": 175.0,
+        "age": 30,
+        "sexe": "male",
+        "activity_factor": 1.2,
+        "goal": "maintien",
+    }
+    monkeypatch.setattr(db, "get_user", lambda *_: user)
+
+    # Aucun repas ni activité
+    monkeypatch.setattr(db, "get_meals", lambda *_, **__: [])
+    monkeypatch.setattr(db, "get_meal_items", lambda *_: [])
+    monkeypatch.setattr(db, "get_activities", lambda *_, **__: [])
+    services.update_daily_summary("u1", "2024-01-01")
+    assert store[0]["calories_apportees"] == 0
+    assert store[0]["calories_brulees"] == 0
+    assert store[0]["num_meals"] == 0
+    assert store[0]["num_activities"] == 0
+
+    # Ajout d'un repas
+    monkeypatch.setattr(db, "get_meals", lambda *_, **__: [{"id": "m1"}])
+    monkeypatch.setattr(
+        db,
+        "get_meal_items",
+        lambda *_: [
+            {
+                "calories": 500,
+                "proteines_g": 30,
+                "glucides_g": 50,
+                "lipides_g": 20,
+            }
+        ],
+    )
+    services.update_daily_summary("u1", "2024-01-01")
+    assert store[0]["calories_apportees"] == 500
+    assert store[0]["num_meals"] == 1
+
+    # Ajout d'une activité
+    monkeypatch.setattr(
+        db, "get_activities", lambda *_, **__: [{"calories_brulees": 200, "duree_min": 30}]
+    )
+    services.update_daily_summary("u1", "2024-01-01")
+    assert store[0]["calories_brulees"] == 200
+    assert store[0]["num_activities"] == 1
+    assert "tdee" in store[0]


### PR DESCRIPTION
## Summary
- recalcul du `daily_summary` incluant TDEE, conseil personnalisé et comptages repas/activités
- déclenchement automatique du recalcul après modification ou suppression de repas et d'ingrédients
- ajout d'un test unitaire vérifiant la mise à jour dynamique

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68988499510c8325a906318294a78808