### PR TITLE
docs(frontend): personnalise le README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,73 +1,20 @@
-# Welcome to your Lovable project
+# Frontend NutriFlow
 
-## Project info
+Bienvenue ! Ce dossier contient l'interface web de NutriFlow. Elle est développée avec **React**, **TypeScript** et **Vite**, stylisée avec **Tailwind CSS** et les composants **shadcn/ui**. L'objectif est de te proposer une application rapide et agréable pour suivre tes repas et tes activités en s'appuyant sur l'API NutriFlow.
 
-**URL**: https://lovable.dev/projects/268e3946-0929-4e6b-b0e8-b9f009e51506
+## Prise en main
 
-## How can I edit this code?
+Assure-toi d'avoir Node.js et npm installés.
 
-There are several ways of editing your application.
-
-**Use Lovable**
-
-Simply visit the [Lovable Project](https://lovable.dev/projects/268e3946-0929-4e6b-b0e8-b9f009e51506) and start prompting.
-
-Changes made via Lovable will be committed automatically to this repo.
-
-**Use your preferred IDE**
-
-If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
-
-The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
-
-Follow these steps:
-
-```sh
-# Step 1: Clone the repository using the project's Git URL.
-git clone <YOUR_GIT_URL>
-
-# Step 2: Navigate to the project directory.
-cd <YOUR_PROJECT_NAME>
-
-# Step 3: Install the necessary dependencies.
-npm i
-
-# Step 4: Start the development server with auto-reloading and an instant preview.
-npm run dev
+```bash
+npm install      # installe les dépendances
+npm run dev      # lance le serveur de développement
+npm run build    # génère une version de production
+npm run preview  # prévisualise la version buildée
+npm run lint     # vérifie la qualité du code
+npm test         # exécute les tests avec Vitest
 ```
 
-**Edit a file directly in GitHub**
+## Aller plus loin
 
-- Navigate to the desired file(s).
-- Click the "Edit" button (pencil icon) at the top right of the file view.
-- Make your changes and commit the changes.
-
-**Use GitHub Codespaces**
-
-- Navigate to the main page of your repository.
-- Click on the "Code" button (green button) near the top right.
-- Select the "Codespaces" tab.
-- Click on "New codespace" to launch a new Codespace environment.
-- Edit files directly within the Codespace and commit and push your changes once you're done.
-
-## What technologies are used for this project?
-
-This project is built with:
-
-- Vite
-- TypeScript
-- React
-- shadcn-ui
-- Tailwind CSS
-
-## How can I deploy this project?
-
-Simply open [Lovable](https://lovable.dev/projects/268e3946-0929-4e6b-b0e8-b9f009e51506) and click on Share -> Publish.
-
-## Can I connect a custom domain to my Lovable project?
-
-Yes, you can!
-
-To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
-
-Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+- [Documentation de l'API backend](../README.md)


### PR DESCRIPTION
## Summary
- remplace le README générique par une présentation du frontend NutriFlow
- ajoute les commandes principales (install, dev, build, lint, test)
- pointe vers la documentation backend

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f015720f8832589f46abd87455b0e